### PR TITLE
fix(attachments): correct mcp workspace mapping

### DIFF
--- a/internal/handlers/team_resources.go
+++ b/internal/handlers/team_resources.go
@@ -2109,10 +2109,10 @@ var supportedAttachmentKinds = map[string]attachmentKindConfig{
 	},
 	"mcpServer_workspaceConfiguration": {
 		Kind:         "mcpServer_workspaceConfiguration",
-		SourceType:   "workspaceConfiguration",
-		TargetType:   "mcpServer",
-		SourceHandle: "$self",
-		TargetHandle: "workspace",
+		SourceType:   "mcpServer",
+		TargetType:   "workspaceConfiguration",
+		SourceHandle: "workspace",
+		TargetHandle: "$self",
 	},
 }
 

--- a/internal/handlers/team_test.go
+++ b/internal/handlers/team_test.go
@@ -905,6 +905,98 @@ func TestTeamPostAttachments(t *testing.T) {
 	stub.AssertDone()
 }
 
+func TestTeamPostAttachmentsMcpServerWorkspaceConfiguration(t *testing.T) {
+	stub := &stubPlatformClient{t: t}
+	mcpServerID := uuid.MustParse("abababab-abab-abab-abab-abababababab")
+	workspaceID := uuid.MustParse("cdcdcdcd-cdcd-cdcd-cdcd-cdcdcdcdcdcd")
+	graph := newGraphDocument([]graphNode{
+		{
+			ID:       mcpServerID.String(),
+			Template: mcpServerTemplateName,
+		},
+		{
+			ID:       workspaceID.String(),
+			Template: workspaceTemplateName,
+		},
+	}, nil, nil)
+
+	stub.Expect(stubCall{
+		Method:       http.MethodGet,
+		Path:         "/api/graph",
+		Status:       http.StatusOK,
+		ResponseJSON: mustMarshalGraph(t, graph),
+	})
+
+	stub.Expect(stubCall{
+		Method: http.MethodPost,
+		Path:   "/api/graph",
+		Responder: func(body any) (int, string, error) {
+			graphBody := mustGraphWriteDocument(t, body)
+			if len(graphBody.Edges) != 1 {
+				t.Fatalf("expected 1 edge, got %d", len(graphBody.Edges))
+			}
+			edge := graphBody.Edges[0]
+			if edge.Source != mcpServerID.String() || edge.Target != workspaceID.String() {
+				t.Fatalf("unexpected edge endpoints: %+v", edge)
+			}
+			if edge.SourceHandle != "workspace" || edge.TargetHandle != "$self" {
+				t.Fatalf("unexpected handles: %+v", edge)
+			}
+			if edge.ID == nil {
+				t.Fatalf("edge ID missing")
+			}
+			createdKey := attachmentCreatedAtKey(*edge.ID)
+			updatedKey := attachmentUpdatedAtKey(*edge.ID)
+			foundCreated := false
+			foundUpdated := false
+			for _, variable := range graphBody.Variables {
+				if variable.Key == createdKey {
+					foundCreated = true
+				}
+				if variable.Key == updatedKey {
+					foundUpdated = true
+				}
+			}
+			if !foundCreated || !foundUpdated {
+				t.Fatalf("attachment timestamps missing: %v", graphBody.Variables)
+			}
+			return http.StatusOK, mustMarshalGraph(t, graphResponseFromWrite(graphBody, graph.UpdatedAt)), nil
+		},
+	})
+
+	h := NewTeam(stub)
+
+	resp, err := h.PostAttachments(context.Background(), gen.PostAttachmentsRequestObject{
+		Body: &gen.PostAttachmentsJSONRequestBody{
+			Kind:     gen.PostAttachmentsJSONBodyKindMcpServerWorkspaceConfiguration,
+			SourceId: mcpServerID,
+			TargetId: workspaceID,
+		},
+	})
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	created, ok := resp.(gen.PostAttachments201JSONResponse)
+	if !ok {
+		t.Fatalf("unexpected response type: %T", resp)
+	}
+	if string(created.Kind) != "mcpServer_workspaceConfiguration" {
+		t.Fatalf("unexpected kind: %s", created.Kind)
+	}
+	if created.SourceType != gen.PostAttachments201JSONResponseSourceType("mcpServer") {
+		t.Fatalf("unexpected source type: %s", created.SourceType)
+	}
+	if created.TargetType != gen.PostAttachments201JSONResponseTargetType("workspaceConfiguration") {
+		t.Fatalf("unexpected target type: %s", created.TargetType)
+	}
+	if created.CreatedAt.IsZero() {
+		t.Fatalf("expected createdAt")
+	}
+
+	stub.AssertDone()
+}
+
 func TestTeamGetAttachments(t *testing.T) {
 	stub := &stubPlatformClient{t: t}
 	agentID := uuid.MustParse("77777777-7777-7777-7777-777777777777")


### PR DESCRIPTION
## Summary
- fix mcpServer_workspaceConfiguration attachment mapping
- add HTTP handler test for mcp server/workspace attachment creation

## Testing
- `nix shell nixpkgs#nodejs -c npx --yes @stoplight/spectral-cli lint spec/openapi.yaml`
- `set -e; git fetch origin main --depth=1 || true; mkdir -p dist; BASE_DIR=$(mktemp -d); if git rev-parse --verify origin/main >/dev/null 2>&1 && git cat-file -e origin/main:spec/openapi.yaml 2>/dev/null; then git archive --format=tar origin/main spec | tar -x -C "$BASE_DIR"; nix shell nixpkgs#nodejs -c npx --yes @redocly/cli bundle "$BASE_DIR/spec/openapi.yaml" -o dist/base.yaml; else nix shell nixpkgs#nodejs -c npx --yes @redocly/cli bundle spec/openapi.yaml -o dist/base.yaml; fi; nix shell nixpkgs#nodejs -c npx --yes @redocly/cli bundle spec/openapi.yaml -o dist/head.yaml; /root/go/bin/oasdiff breaking --fail-on ERR dist/base.yaml dist/head.yaml`
- `set -e; /root/go/bin/oapi-codegen --config oapi-codegen.server.yaml spec/openapi.yaml; nix shell nixpkgs#go -c gofmt -w internal/gen/server.gen.go; git diff --exit-code internal/gen/server.gen.go`
- `nix shell nixpkgs#go nixpkgs#gcc -c go vet ./...`
- `nix shell nixpkgs#go nixpkgs#gcc -c go test ./...`
- `set -e; mkdir -p dist; nix shell nixpkgs#nodejs -c npx --yes @redocly/cli build-docs spec/openapi.yaml --output dist/redoc.html`

Closes #11