### PR TITLE
Standardize files gRPC target port

### DIFF
--- a/internal/platform/config_test.go
+++ b/internal/platform/config_test.go
@@ -7,7 +7,7 @@ import (
 
 func TestLoadConfigFromEnv(t *testing.T) {
 	t.Setenv("PLATFORM_BASE_URL", "https://api.example.com/team")
-	t.Setenv("FILES_GRPC_TARGET", "files:9090")
+	t.Setenv("FILES_GRPC_TARGET", "files:50051")
 	t.Setenv("PLATFORM_TIMEOUT_MS", "1500")
 	t.Setenv("PLATFORM_RETRIES", "3")
 	t.Setenv("PLATFORM_AUTH_TOKEN", "secret")
@@ -22,7 +22,7 @@ func TestLoadConfigFromEnv(t *testing.T) {
 		t.Fatalf("unexpected baseURL: %s", got)
 	}
 
-	if got := cfg.FilesGRPCTarget; got != "files:9090" {
+	if got := cfg.FilesGRPCTarget; got != "files:50051" {
 		t.Fatalf("unexpected files grpc target: %s", got)
 	}
 


### PR DESCRIPTION
## Summary
- update Files gRPC target example port to 50051 in configuration tests

## Testing
- buf generate buf.build/agynio/api --template buf.gen.yaml --path agynio/api/files/v1/files.proto
- nix shell nixpkgs#nodejs -c npx --yes @stoplight/spectral-cli lint spec/openapi.yaml
- nix shell nixpkgs#nodejs -c npx --yes @redocly/cli bundle spec/openapi.yaml -o dist/base.yaml
- nix shell nixpkgs#nodejs -c npx --yes @redocly/cli bundle spec/openapi.yaml -o dist/head.yaml
- /root/go/bin/oasdiff breaking --fail-on ERR dist/base.yaml dist/head.yaml
- /root/go/bin/oapi-codegen --config oapi-codegen.server.yaml spec/openapi.yaml
- gofmt -w internal/gen/server.gen.go
- git diff --exit-code internal/gen/server.gen.go
- nix shell nixpkgs#go nixpkgs#gcc -c go vet ./...
- nix shell nixpkgs#go nixpkgs#gcc -c go test ./...
- nix shell nixpkgs#nodejs -c npx --yes @redocly/cli build-docs spec/openapi.yaml --output dist/redoc.html
- nix shell nixpkgs#kubernetes-helm -c helm dependency build charts/gateway
- nix shell nixpkgs#kubernetes-helm -c helm lint charts/gateway --set gateway.platformBaseUrl=https://platform.example.com

Refs #21