### PR TITLE
Remove config defaults from schemas

### DIFF
--- a/internal/apischema/teamv1/components/schemas/AgentConfig.yaml
+++ b/internal/apischema/teamv1/components/schemas/AgentConfig.yaml
@@ -1,16 +1,16 @@
 type: object
 properties:
-  model: { type: string, default: 'gpt-5' }
-  systemPrompt: { type: string, default: 'You are a helpful AI assistant.' }
-  debounceMs: { type: integer, minimum: 0, default: 0 }
-  whenBusy: { type: string, enum: ['wait', 'injectAfterTools'], default: 'wait' }
-  processBuffer: { type: string, enum: ['allTogether', 'oneByOne'], default: 'allTogether' }
-  sendFinalResponseToThread: { type: boolean, default: true }
-  summarizationKeepTokens: { type: integer, minimum: 0, default: 0 }
-  summarizationMaxTokens: { type: integer, minimum: 1, default: 512 }
-  restrictOutput: { type: boolean, default: false }
-  restrictionMessage: { type: string, default: "Do not produce a final answer directly. Before finishing, call a tool. If no tool is needed, call the 'finish' tool." }
-  restrictionMaxInjections: { type: integer, minimum: 0, default: 0 }
+  model: { type: string }
+  systemPrompt: { type: string }
+  debounceMs: { type: integer, minimum: 0 }
+  whenBusy: { type: string, enum: ['wait', 'injectAfterTools'] }
+  processBuffer: { type: string, enum: ['allTogether', 'oneByOne'] }
+  sendFinalResponseToThread: { type: boolean }
+  summarizationKeepTokens: { type: integer, minimum: 0 }
+  summarizationMaxTokens: { type: integer, minimum: 1 }
+  restrictOutput: { type: boolean }
+  restrictionMessage: { type: string }
+  restrictionMaxInjections: { type: integer, minimum: 0 }
   name: { type: string }
   role: { type: string }
 additionalProperties: false

--- a/internal/apischema/teamv1/components/schemas/McpServerConfig.yaml
+++ b/internal/apischema/teamv1/components/schemas/McpServerConfig.yaml
@@ -13,7 +13,7 @@ properties:
   restart:
     type: object
     properties:
-      maxAttempts: { type: integer, minimum: 1, default: 5 }
-      backoffMs: { type: integer, minimum: 1, default: 2000 }
+      maxAttempts: { type: integer, minimum: 1 }
+      backoffMs: { type: integer, minimum: 1 }
     additionalProperties: false
 additionalProperties: false

--- a/internal/apischema/teamv1/components/schemas/MemoryBucketConfig.yaml
+++ b/internal/apischema/teamv1/components/schemas/MemoryBucketConfig.yaml
@@ -3,6 +3,5 @@ properties:
   scope:
     type: string
     enum: [global, perThread]
-    default: global
   collectionPrefix: { type: string }
 additionalProperties: false

--- a/internal/apischema/teamv1/components/schemas/WorkspaceConfig.yaml
+++ b/internal/apischema/teamv1/components/schemas/WorkspaceConfig.yaml
@@ -14,8 +14,8 @@ properties:
       - { type: number }
       - { type: string }
   platform: { $ref: './WorkspacePlatform.yaml' }
-  enableDinD: { type: boolean, default: false }
-  ttlSeconds: { type: integer, minimum: 0, default: 86400 }
+  enableDinD: { type: boolean }
+  ttlSeconds: { type: integer, minimum: 0 }
   nix: { type: object }
   volumes: { $ref: './WorkspaceVolumeConfig.yaml' }
 additionalProperties: false

--- a/internal/apischema/teamv1/components/schemas/WorkspaceVolumeConfig.yaml
+++ b/internal/apischema/teamv1/components/schemas/WorkspaceVolumeConfig.yaml
@@ -1,5 +1,5 @@
 type: object
 properties:
-  enabled: { type: boolean, default: false }
+  enabled: { type: boolean }
   mountPath: { type: string, pattern: '^/' }
 additionalProperties: false

--- a/spec/components/schemas/AgentConfig.yaml
+++ b/spec/components/schemas/AgentConfig.yaml
@@ -1,16 +1,16 @@
 type: object
 properties:
-  model: { type: string, default: 'gpt-5' }
-  systemPrompt: { type: string, default: 'You are a helpful AI assistant.' }
-  debounceMs: { type: integer, minimum: 0, default: 0 }
-  whenBusy: { type: string, enum: ['wait', 'injectAfterTools'], default: 'wait' }
-  processBuffer: { type: string, enum: ['allTogether', 'oneByOne'], default: 'allTogether' }
-  sendFinalResponseToThread: { type: boolean, default: true }
-  summarizationKeepTokens: { type: integer, minimum: 0, default: 0 }
-  summarizationMaxTokens: { type: integer, minimum: 1, default: 512 }
-  restrictOutput: { type: boolean, default: false }
-  restrictionMessage: { type: string, default: "Do not produce a final answer directly. Before finishing, call a tool. If no tool is needed, call the 'finish' tool." }
-  restrictionMaxInjections: { type: integer, minimum: 0, default: 0 }
+  model: { type: string }
+  systemPrompt: { type: string }
+  debounceMs: { type: integer, minimum: 0 }
+  whenBusy: { type: string, enum: ['wait', 'injectAfterTools'] }
+  processBuffer: { type: string, enum: ['allTogether', 'oneByOne'] }
+  sendFinalResponseToThread: { type: boolean }
+  summarizationKeepTokens: { type: integer, minimum: 0 }
+  summarizationMaxTokens: { type: integer, minimum: 1 }
+  restrictOutput: { type: boolean }
+  restrictionMessage: { type: string }
+  restrictionMaxInjections: { type: integer, minimum: 0 }
   name: { type: string }
   role: { type: string }
 additionalProperties: false

--- a/spec/components/schemas/McpServerConfig.yaml
+++ b/spec/components/schemas/McpServerConfig.yaml
@@ -13,7 +13,7 @@ properties:
   restart:
     type: object
     properties:
-      maxAttempts: { type: integer, minimum: 1, default: 5 }
-      backoffMs: { type: integer, minimum: 1, default: 2000 }
+      maxAttempts: { type: integer, minimum: 1 }
+      backoffMs: { type: integer, minimum: 1 }
     additionalProperties: false
 additionalProperties: false

--- a/spec/components/schemas/MemoryBucketConfig.yaml
+++ b/spec/components/schemas/MemoryBucketConfig.yaml
@@ -3,6 +3,5 @@ properties:
   scope:
     type: string
     enum: [global, perThread]
-    default: global
   collectionPrefix: { type: string }
 additionalProperties: false

--- a/spec/components/schemas/WorkspaceConfig.yaml
+++ b/spec/components/schemas/WorkspaceConfig.yaml
@@ -14,8 +14,8 @@ properties:
       - { type: number }
       - { type: string }
   platform: { $ref: './WorkspacePlatform.yaml' }
-  enableDinD: { type: boolean, default: false }
-  ttlSeconds: { type: integer, minimum: 0, default: 86400 }
+  enableDinD: { type: boolean }
+  ttlSeconds: { type: integer, minimum: 0 }
   nix: { type: object }
   volumes: { $ref: './WorkspaceVolumeConfig.yaml' }
 additionalProperties: false

--- a/spec/components/schemas/WorkspaceVolumeConfig.yaml
+++ b/spec/components/schemas/WorkspaceVolumeConfig.yaml
@@ -1,5 +1,5 @@
 type: object
 properties:
-  enabled: { type: boolean, default: false }
+  enabled: { type: boolean }
   mountPath: { type: string, pattern: '^/' }
 additionalProperties: false


### PR DESCRIPTION
## Summary
- remove default values from config schema properties in spec components
- sync embedded teamv1 schema copy with updated defaults

## Testing
- nix shell nixpkgs#buf -c buf generate buf.build/agynio/api --path agynio/api/files/v1
- nix shell nixpkgs#nodejs -c npx --yes @stoplight/spectral-cli lint spec/openapi.yaml (97 warnings, 0 errors)
- nix shell nixpkgs#go nixpkgs#nodejs -c bash -c 'set -euo pipefail

git fetch origin main --depth=1 || true
mkdir -p dist
BASE_DIR="$(mktemp -d)"
if git rev-parse --verify origin/main >/dev/null 2>&1 && git cat-file -e origin/main:spec/openapi.yaml 2>/dev/null; then
  git archive --format=tar origin/main spec | tar -x -C "$BASE_DIR"
  npx --yes @redocly/cli bundle "$BASE_DIR/spec/openapi.yaml" -o dist/base.yaml
else
  npx --yes @redocly/cli bundle spec/openapi.yaml -o dist/base.yaml
fi
npx --yes @redocly/cli bundle spec/openapi.yaml -o dist/head.yaml
"$(go env GOPATH)/bin/oasdiff" breaking --fail-on ERR dist/base.yaml dist/head.yaml
'
- nix shell nixpkgs#go nixpkgs#gcc -c bash -c '"$(go env GOPATH)/bin/oapi-codegen" --config oapi-codegen.server.yaml spec/openapi.yaml && gofmt -w internal/gen/server.gen.go && git diff --exit-code internal/gen/server.gen.go'
- nix shell nixpkgs#go nixpkgs#gcc -c go vet ./...
- nix shell nixpkgs#go nixpkgs#gcc -c go test ./...
- nix shell nixpkgs#nodejs -c bash -c 'mkdir -p dist && npx --yes @redocly/cli build-docs spec/openapi.yaml --output dist/redoc.html'

Refs #18