### PR TITLE
fix(docker): run buf generate in image

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -3,6 +3,7 @@
 charts
 dist
 .openapi
+gen/
 *.log
 node_modules
 tmp

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,41 +1,42 @@
 # syntax=docker/dockerfile:1.7
-
 ARG GO_VERSION=1.22
+ARG BUF_VERSION=1.64.0
 
+# Stage 1: Download buf binary
+FROM --platform=$BUILDPLATFORM golang:${GO_VERSION}-bookworm AS buf
+ARG BUF_VERSION
+RUN curl -sSL \
+      "https://github.com/bufbuild/buf/releases/download/v${BUF_VERSION}/buf-$(uname -s)-$(uname -m)" \
+      -o /usr/local/bin/buf && \
+    chmod +x /usr/local/bin/buf
+
+# Stage 2: Generate + compile
 FROM --platform=$BUILDPLATFORM golang:${GO_VERSION}-bookworm AS build
-
 WORKDIR /src
+ENV CGO_ENABLED=0 GO111MODULE=on
 
-ENV CGO_ENABLED=0 \
-    GO111MODULE=on
+COPY --from=buf /usr/local/bin/buf /usr/local/bin/buf
 
 COPY go.mod go.sum ./
-
 RUN --mount=type=cache,target=/root/.cache/go-build \
     --mount=type=cache,target=/root/go/pkg/mod \
-    go mod download && \
-    go mod verify
+    go mod download && go mod verify
+
+COPY buf.gen.yaml ./
+RUN buf generate buf.build/agynio/api --path agynio/api/files/v1
 
 COPY . .
 
-ARG TARGETOS
-ARG TARGETARCH
-
+ARG TARGETOS TARGETARCH
 RUN --mount=type=cache,target=/root/.cache/go-build \
     --mount=type=cache,target=/root/go/pkg/mod \
     GOOS=$TARGETOS GOARCH=$TARGETARCH go build \
-      -trimpath \
-      -ldflags="-s -w" \
-      -o /out/gateway ./cmd/gateway
+      -trimpath -ldflags="-s -w" -o /out/gateway ./cmd/gateway
 
+# Stage 3: Runtime
 FROM gcr.io/distroless/static-debian12:nonroot
-
 WORKDIR /app
-
 LABEL org.opencontainers.image.source="https://github.com/agynio/gateway"
-
 COPY --from=build /out/gateway ./gateway
-
 EXPOSE 8080
-
 ENTRYPOINT ["/app/gateway"]


### PR DESCRIPTION
## Summary
- update the Docker build to fetch buf and generate gRPC stubs before compiling
- align Docker build args for buf versioning and keep multi-stage layout explicit
- ignore generated gen/ output in Docker build context

## Testing
- docker buildx build --platform linux/amd64 -t agynio/gateway:test .
- nix shell nixpkgs#oras -c bash scripts/pull-spec.sh
- nix shell nixpkgs#buf -c buf generate buf.build/agynio/api --path agynio/api/files/v1
- nix shell nixpkgs#nodejs -c npx --yes @stoplight/spectral-cli lint .openapi/team-v1.yaml
- set -eu; mkdir -p dist; git fetch origin main --depth=1 || true; if git rev-parse --verify origin/main >/dev/null 2>&1 && git cat-file -e origin/main:internal/apischema/teamv1/team-v1.yaml 2>/dev/null; then git show origin/main:internal/apischema/teamv1/team-v1.yaml > dist/base.yaml; else cp .openapi/team-v1.yaml dist/base.yaml; fi; cp .openapi/team-v1.yaml dist/head.yaml; /root/go/bin/oasdiff breaking --fail-on ERR dist/base.yaml dist/head.yaml
- nix shell nixpkgs#go nixpkgs#gcc -c sh -c '/root/go/bin/oapi-codegen --config oapi-codegen.server.yaml .openapi/team-v1.yaml && gofmt -w internal/gen/server.gen.go && git diff --exit-code internal/gen/server.gen.go'
- set -eu; bash scripts/sync-embedded-spec.sh; git diff --exit-code internal/apischema/teamv1/team-v1.yaml
- nix shell nixpkgs#go nixpkgs#gcc -c go vet ./...
- nix shell nixpkgs#go nixpkgs#gcc -c go test ./...
- nix shell nixpkgs#nodejs -c npx --yes @redocly/cli build-docs .openapi/team-v1.yaml --output dist/redoc.html

Closes #25