### PR TITLE
feat: add devspace dev configuration for local development

### DIFF
--- a/.air.toml
+++ b/.air.toml
@@ -1,0 +1,12 @@
+root = "."
+tmp_dir = "tmp"
+
+[build]
+  cmd = "go build -o ./tmp/gateway ./cmd/gateway"
+  bin = "./tmp/gateway"
+  include_ext = ["go", "yaml"]
+  exclude_dir = ["gen", ".git", "tmp", ".devspace", ".openapi", "charts", "dist"]
+  delay = 1000
+
+[log]
+  time = false

--- a/devspace.yaml
+++ b/devspace.yaml
@@ -1,0 +1,111 @@
+version: v2beta1
+
+vars:
+  GATEWAY_NAMESPACE: gateway
+
+pipelines:
+  dev: |-
+    if kubectl get application gateway -n argocd >/dev/null 2>&1; then
+      echo "Disabling ArgoCD auto-sync for gateway..."
+      kubectl patch application gateway -n argocd \
+        --type merge \
+        -p '{"spec":{"syncPolicy":{"automated":null}}}'
+      echo "ArgoCD auto-sync disabled."
+    else
+      echo "WARNING: ArgoCD Application 'gateway' not found in argocd namespace."
+    fi
+    echo "Patching gateway deployment for DevSpace..."
+    kubectl patch deployment gateway -n ${GATEWAY_NAMESPACE} --type strategic --patch "$(cat <<'EOF'
+    spec:
+      template:
+        spec:
+          securityContext:
+            runAsUser: 1000
+            fsGroup: 1000
+          initContainers: []
+          containers:
+            - name: gateway
+              image: ghcr.io/agynio/devcontainer-go:1
+              workingDir: /opt/app/data
+              command:
+                - sh
+                - -c
+                - |
+                  set -eu
+                  elapsed=0
+                  while [ ! -f /opt/app/data/go.mod ]; do
+                    sleep 1; elapsed=$((elapsed + 1))
+                    [ "$elapsed" -ge 120 ] && { echo "ERROR: sync timeout" >&2; exit 1; }
+                  done
+                  exec /opt/app/data/scripts/devspace-startup.sh
+              resources:
+                requests:
+                  cpu: 500m
+                  memory: 1Gi
+                limits:
+                  cpu: "2"
+                  memory: 4Gi
+              securityContext:
+                runAsNonRoot: true
+                runAsUser: 1000
+                runAsGroup: 1000
+                readOnlyRootFilesystem: false
+                allowPrivilegeEscalation: false
+                capabilities:
+                  drop: ["ALL"]
+                seccompProfile:
+                  type: RuntimeDefault
+    EOF
+    )"
+    start_dev --disable-pod-replace gateway
+
+hooks:
+  - name: restore-argocd-auto-sync
+    events:
+      - after:dev:gateway
+    command: sh
+    args:
+      - -c
+      - |
+        if kubectl get application gateway -n argocd >/dev/null 2>&1; then
+          echo "Re-enabling ArgoCD auto-sync for gateway..."
+          kubectl patch application gateway -n argocd \
+            --type merge \
+            -p '{"spec":{"syncPolicy":{"automated":{"prune":true,"selfHeal":true}}}}'
+          echo "ArgoCD auto-sync restored."
+        fi
+
+dev:
+  gateway:
+    namespace: ${GATEWAY_NAMESPACE}
+    labelSelector:
+      app.kubernetes.io/name: gateway
+      app.kubernetes.io/instance: gateway
+    containers:
+      gateway:
+        container: gateway
+        sync:
+          - path: ./:/opt/app/data
+            excludePaths:
+              - .git/
+              - gen/
+              - .openapi/
+              - dist/
+              - .devspace/
+              - gateway.log
+              - gateway.pid
+            uploadExcludePaths:
+              - .git/
+              - gen/
+              - .openapi/
+              - dist/
+            downloadExcludePaths:
+              - .git/
+              - gen/
+              - .openapi/
+              - dist/
+        logs:
+          enabled: true
+          lastLines: 200
+    ports:
+      - port: "8080"

--- a/scripts/devspace-startup.sh
+++ b/scripts/devspace-startup.sh
@@ -1,0 +1,13 @@
+#!/usr/bin/env bash
+set -eu
+
+echo "=== DevSpace startup ==="
+
+echo "Generating protobuf types..."
+buf generate buf.build/agynio/api --path agynio/api/files/v1
+
+echo "Downloading Go modules..."
+go mod download
+
+echo "Starting dev server (air)..."
+exec air


### PR DESCRIPTION
## Summary
- add DevSpace pipeline and dev configuration for the gateway deployment
- add DevSpace startup script and Air config for Go dev flow

## Testing
- nix shell nixpkgs#oras -c bash scripts/pull-spec.sh
- nix shell nixpkgs#buf -c buf generate buf.build/agynio/api --path agynio/api/files/v1
- nix shell nixpkgs#nodejs -c npx --yes @stoplight/spectral-cli lint .openapi/team-v1.yaml
- bash -c "set -euo pipefail
  mkdir -p dist
  git fetch origin main --depth=1 || true
  if git rev-parse --verify origin/main >/dev/null 2>&1 && git cat-file -e origin/main:internal/apischema/teamv1/team-v1.yaml 2>/dev/null; then
    git show origin/main:internal/apischema/teamv1/team-v1.yaml > dist/base.yaml
  else
    cp .openapi/team-v1.yaml dist/base.yaml
  fi
  cp .openapi/team-v1.yaml dist/head.yaml
  /root/go/bin/oasdiff breaking --fail-on ERR dist/base.yaml dist/head.yaml"
- nix shell nixpkgs#go nixpkgs#gcc -c bash -c "set -euo pipefail
  /root/go/bin/oapi-codegen --config oapi-codegen.server.yaml .openapi/team-v1.yaml
  gofmt -w internal/gen/server.gen.go
  git diff --exit-code internal/gen/server.gen.go"
- bash scripts/sync-embedded-spec.sh
- nix shell nixpkgs#go nixpkgs#gcc -c go vet ./...
- nix shell nixpkgs#go nixpkgs#gcc -c go test ./...

Refs #28