### PR TITLE
fix: correct devspace namespace to platform

### DIFF
--- a/devspace.yaml
+++ b/devspace.yaml
@@ -1,7 +1,7 @@
 version: v2beta1
 
 vars:
-  GATEWAY_NAMESPACE: gateway
+  GATEWAY_NAMESPACE: platform
 
 pipelines:
   dev: |-


### PR DESCRIPTION
The gateway service is deployed to the 'platform' namespace by bootstrap_v2, not a dedicated 'gateway' namespace. Fixes the devspace dev configuration to target the correct namespace.

Refs #28