### PR TITLE
fix: correct deployment name for devspace patch

### DIFF
--- a/devspace.yaml
+++ b/devspace.yaml
@@ -15,7 +15,7 @@ pipelines:
       echo "WARNING: ArgoCD Application 'gateway' not found in argocd namespace."
     fi
     echo "Patching gateway deployment for DevSpace..."
-    kubectl patch deployment gateway -n ${GATEWAY_NAMESPACE} --type strategic --patch "$(cat <<'EOF'
+    kubectl patch deployment gateway-gateway -n ${GATEWAY_NAMESPACE} --type strategic --patch "$(cat <<'EOF'
     spec:
       template:
         spec:


### PR DESCRIPTION
## Summary
- update the devspace pipeline to patch the Helm deployment name

## Testing
- ./scripts/pull-spec.sh
- buf generate buf.build/agynio/api --path agynio/api/files/v1
- PATH=\"$(npm prefix -g)/bin:$PATH\" spectral lint .openapi/team-v1.yaml
- bash -c \"set -euo pipefail
  mkdir -p dist
  git fetch origin main --depth=1 || true
  if git rev-parse --verify origin/main >/dev/null 2>&1 \\n     && git cat-file -e origin/main:internal/apischema/teamv1/team-v1.yaml 2>/dev/null; then
    git show origin/main:internal/apischema/teamv1/team-v1.yaml > dist/base.yaml
  else
    cp .openapi/team-v1.yaml dist/base.yaml
  fi
  cp .openapi/team-v1.yaml dist/head.yaml
  PATH=\\\"$(go env GOPATH)/bin:$PATH\\\" oasdiff breaking --fail-on ERR dist/base.yaml dist/head.yaml\"
- bash -c \"set -euo pipefail
  PATH=\\\"$(go env GOPATH)/bin:$PATH\\\" oapi-codegen --config oapi-codegen.server.yaml .openapi/team-v1.yaml
  gofmt -w internal/gen/server.gen.go
  git diff --exit-code internal/gen/server.gen.go\"
- bash -c \"set -euo pipefail
  ./scripts/sync-embedded-spec.sh
  git diff --exit-code internal/apischema/teamv1/team-v1.yaml\"
- go vet ./...
- go test ./...
- PATH=\"$(npm prefix -g)/bin:$PATH\" redocly build-docs .openapi/team-v1.yaml --output dist/redoc.html

## Issue
- #28