### PR TITLE
fix: add devspace emptyDir volume

### DIFF
--- a/devspace.yaml
+++ b/devspace.yaml
@@ -23,6 +23,9 @@ pipelines:
             runAsUser: 1000
             fsGroup: 1000
           initContainers: []
+          volumes:
+            - name: data
+              emptyDir: {}
           containers:
             - name: gateway
               image: ghcr.io/agynio/devcontainer-go:1
@@ -38,6 +41,9 @@ pipelines:
                     [ "$elapsed" -ge 120 ] && { echo "ERROR: sync timeout" >&2; exit 1; }
                   done
                   exec /opt/app/data/scripts/devspace-startup.sh
+              volumeMounts:
+                - name: data
+                  mountPath: /opt/app/data
               resources:
                 requests:
                   cpu: 500m


### PR DESCRIPTION
## Summary
- mount an emptyDir at /opt/app/data in the devspace patch
- add the matching volume mount to the gateway container

## Testing
- ./scripts/pull-spec.sh
- buf generate buf.build/agynio/api --path agynio/api/files/v1
- PATH=\"$(npm prefix -g)/bin:$PATH\" spectral lint .openapi/team-v1.yaml
- bash -c \"set -euo pipefail
  mkdir -p dist
  git fetch origin main --depth=1 || true
  if git rev-parse --verify origin/main >/dev/null 2>&1 \\\n     && git cat-file -e origin/main:internal/apischema/teamv1/team-v1.yaml 2>/dev/null; then
    git show origin/main:internal/apischema/teamv1/team-v1.yaml > dist/base.yaml
  else
    cp .openapi/team-v1.yaml dist/base.yaml
  fi
  cp .openapi/team-v1.yaml dist/head.yaml
  PATH=\\\"$(go env GOPATH)/bin:$PATH\\\" oasdiff breaking --fail-on ERR dist/base.yaml dist/head.yaml\"
- bash -c \"set -euo pipefail
  PATH=\\\"$(go env GOPATH)/bin:$PATH\\\" oapi-codegen --config oapi-codegen.server.yaml .openapi/team-v1.yaml
  gofmt -w internal/gen/server.gen.go
  git diff --exit-code internal/gen/server.gen.go\"
- bash -c \"set -euo pipefail
  ./scripts/sync-embedded-spec.sh
  git diff --exit-code internal/apischema/teamv1/team-v1.yaml\"
- go vet ./...
- go test ./...
- PATH=\"$(npm prefix -g)/bin:$PATH\" redocly build-docs .openapi/team-v1.yaml --output dist/redoc.html

## Issue
- #28