### PR TITLE
fix: anchor devspace gen exclude

### DIFF
--- a/devspace.yaml
+++ b/devspace.yaml
@@ -94,7 +94,7 @@ dev:
           - path: ./:/opt/app/data
             excludePaths:
               - .git/
-              - gen/
+              - /gen/
               - .openapi/
               - dist/
               - .devspace/
@@ -102,12 +102,12 @@ dev:
               - gateway.pid
             uploadExcludePaths:
               - .git/
-              - gen/
+              - /gen/
               - .openapi/
               - dist/
             downloadExcludePaths:
               - .git/
-              - gen/
+              - /gen/
               - .openapi/
               - dist/
         logs:


### PR DESCRIPTION
## Summary
- anchor the gen/ sync exclusion to the repo root to keep internal/gen syncing

## Testing
- ./scripts/pull-spec.sh
- buf generate buf.build/agynio/api --path agynio/api/files/v1
- PATH=\"$(npm prefix -g)/bin:$PATH\" spectral lint .openapi/team-v1.yaml (warnings only)
- bash -c \"set -euo pipefail
  mkdir -p dist
  git fetch origin main --depth=1 || true
  if git rev-parse --verify origin/main >/dev/null 2>&1 \\\n     && git cat-file -e origin/main:internal/apischema/teamv1/team-v1.yaml 2>/dev/null; then
    git show origin/main:internal/apischema/teamv1/team-v1.yaml > dist/base.yaml
  else
    cp .openapi/team-v1.yaml dist/base.yaml
  fi
  cp .openapi/team-v1.yaml dist/head.yaml
  PATH=\\\"$(go env GOPATH)/bin:$PATH\\\" oasdiff breaking --fail-on ERR dist/base.yaml dist/head.yaml\"
- bash -c \"set -euo pipefail
  PATH=\\\"$(go env GOPATH)/bin:$PATH\\\" oapi-codegen --config oapi-codegen.server.yaml .openapi/team-v1.yaml
  gofmt -w internal/gen/server.gen.go
  git diff --exit-code internal/gen/server.gen.go\"
- bash -c \"set -euo pipefail
  ./scripts/sync-embedded-spec.sh
  git diff --exit-code internal/apischema/teamv1/team-v1.yaml\"
- go vet ./...
- go test ./...
- PATH=\"$(npm prefix -g)/bin:$PATH\" redocly build-docs .openapi/team-v1.yaml --output dist/redoc.html

## Issue
- #28