### PR TITLE
fix: add teams/v1 proto generation

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -23,7 +23,7 @@ RUN --mount=type=cache,target=/root/.cache/go-build \
     go mod download && go mod verify
 
 COPY buf.gen.yaml ./
-RUN buf generate buf.build/agynio/api --path agynio/api/files/v1 --path agynio/api/llm/v1
+RUN buf generate buf.build/agynio/api --path agynio/api/files/v1 --path agynio/api/llm/v1 --path agynio/api/teams/v1
 
 COPY . .
 

--- a/scripts/devspace-startup.sh
+++ b/scripts/devspace-startup.sh
@@ -4,7 +4,7 @@ set -eu
 echo "=== DevSpace startup ==="
 
 echo "Generating protobuf types..."
-buf generate buf.build/agynio/api --path agynio/api/files/v1 --path agynio/api/llm/v1
+buf generate buf.build/agynio/api --path agynio/api/files/v1 --path agynio/api/llm/v1 --path agynio/api/teams/v1
 
 echo "Downloading Go modules..."
 go mod download


### PR DESCRIPTION
## Summary
- generate teams/v1 protos during DevSpace startup
- keep Dockerfile proto generation in sync with DevSpace

## Testing
- ./scripts/pull-spec.sh
- buf generate buf.build/agynio/api --path agynio/api/files/v1 --path agynio/api/llm/v1 --path agynio/api/teams/v1
- PATH=\"$(npm prefix -g)/bin:$PATH\" spectral lint .openapi/team-v1.yaml (warnings only)
- bash -c \"set -euo pipefail
  mkdir -p dist
  git fetch origin main --depth=1 || true
  if git rev-parse --verify origin/main >/dev/null 2>&1 \\\n     && git cat-file -e origin/main:internal/apischema/teamv1/team-v1.yaml 2>/dev/null; then
    git show origin/main:internal/apischema/teamv1/team-v1.yaml > dist/base.yaml
  else
    cp .openapi/team-v1.yaml dist/base.yaml
  fi
  cp .openapi/team-v1.yaml dist/head.yaml
  PATH=\\\"$(go env GOPATH)/bin:$PATH\\\" oasdiff breaking --fail-on ERR dist/base.yaml dist/head.yaml\"
- bash -c \"set -euo pipefail
  PATH=\\\"$(go env GOPATH)/bin:$PATH\\\" oapi-codegen --config oapi-codegen.server.yaml .openapi/team-v1.yaml
  gofmt -w internal/gen/server.gen.go
  git diff --exit-code internal/gen/server.gen.go\"
- bash -c \"set -euo pipefail
  ./scripts/sync-embedded-spec.sh
  git diff --exit-code internal/apischema/teamv1/team-v1.yaml\"
- go vet ./...
- go test ./...
- PATH=\"$(npm prefix -g)/bin:$PATH\" redocly build-docs .openapi/team-v1.yaml --output dist/redoc.html

## Issue
- #28