### PR TITLE
fix(helm): require teams grpc target

### DIFF
--- a/charts/gateway/Chart.yaml
+++ b/charts/gateway/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: gateway
 description: Helm chart for deploying the agyn gateway service.
 type: application
-version: 0.4.0
+version: 0.4.1
 appVersion: 0.4.0
 home: https://github.com/agynio/gateway
 sources:

--- a/charts/gateway/templates/_helpers.tpl
+++ b/charts/gateway/templates/_helpers.tpl
@@ -4,6 +4,9 @@
 {{- $baseURL := required "gateway.platformBaseUrl is required" (trimAll " \n\t" (default "" .Values.gateway.platformBaseUrl)) -}}
 {{- $env = append $env (dict "name" "PLATFORM_BASE_URL" "value" $baseURL) -}}
 
+{{- $teamsGrpcTarget := required "gateway.teamsGrpcTarget is required" (trimAll " \n\t" (default "" .Values.gateway.teamsGrpcTarget)) -}}
+{{- $env = append $env (dict "name" "TEAMS_GRPC_TARGET" "value" $teamsGrpcTarget) -}}
+
 {{- $filesGrpcTarget := trimAll " \n\t" (default "" .Values.gateway.filesGrpcTarget) -}}
 {{- if $filesGrpcTarget }}
 {{- $env = append $env (dict "name" "FILES_GRPC_TARGET" "value" $filesGrpcTarget) -}}

--- a/charts/gateway/values.yaml
+++ b/charts/gateway/values.yaml
@@ -153,6 +153,7 @@ metrics:
 gateway:
   # Required: target platform server base URL
   platformBaseUrl: "https://api.agyn.dev:8080"
+  teamsGrpcTarget: ""
   filesGrpcTarget: ""
   llmGrpcTarget: ""
   llmHttpBaseUrl: ""


### PR DESCRIPTION
## Summary
- add required TEAMS_GRPC_TARGET Helm env configuration
- expose teamsGrpcTarget in values and bump chart version

## Testing
- go vet ./...
- go test ./...
- go build ./...

## Issue
- #32