### PR TITLE
feat(devspace): add watch flag

### DIFF
--- a/devspace.yaml
+++ b/devspace.yaml
@@ -76,7 +76,7 @@ pipelines:
         healthy=false
         attempts=0
         while [ "$attempts" -lt 60 ]; do
-          if exec_container --label-selector=app.kubernetes.io/name=gateway -n ${GATEWAY_NAMESPACE} -- sh -c 'nc -z localhost 8080 >/dev/null 2>&1 || (echo > /dev/tcp/localhost/8080) >/dev/null 2>&1'; then
+          if exec_container --label-selector=app.kubernetes.io/name=gateway -n ${GATEWAY_NAMESPACE} -- bash -c 'nc -z localhost 8080 >/dev/null 2>&1 || (echo > /dev/tcp/localhost/8080) >/dev/null 2>&1'; then
             healthy=true
             break
           fi


### PR DESCRIPTION
## Summary
- add a watch flag to the dev pipeline to toggle log streaming
- add a run-and-exit health check loop for gateway port 8080
- keep existing patch + hook behavior intact

## Testing
- nix shell nixpkgs#oras -c ./scripts/pull-spec.sh
- nix shell nixpkgs#buf -c buf generate buf.build/agynio/api --path agynio/api/files/v1 --path agynio/api/llm/v1 --path agynio/api/secrets/v1 --path agynio/api/teams/v1
- nix shell nixpkgs#nodejs -c npx --yes @stoplight/spectral-cli lint .openapi/team-v1.yaml
- nix shell nixpkgs#nodejs -c npx --yes @stoplight/spectral-cli lint .openapi/llm-v1.yaml
- bash -c 'set -euo pipefail; mkdir -p dist; git fetch origin main --depth=1 || true; if git rev-parse --verify origin/main >/dev/null 2>&1 && git cat-file -e origin/main:internal/apischema/teamv1/team-v1.yaml 2>/dev/null; then git show origin/main:internal/apischema/teamv1/team-v1.yaml > dist/base.yaml; else cp .openapi/team-v1.yaml dist/base.yaml; fi; cp .openapi/team-v1.yaml dist/head.yaml; ~/go/bin/oasdiff breaking --fail-on ERR dist/base.yaml dist/head.yaml'
- bash -c 'set -euo pipefail; mkdir -p dist; git fetch origin main --depth=1 || true; if git rev-parse --verify origin/main >/dev/null 2>&1 && git cat-file -e origin/main:internal/apischema/llmv1/llm-v1.yaml 2>/dev/null; then git show origin/main:internal/apischema/llmv1/llm-v1.yaml > dist/llm-base.yaml; else cp .openapi/llm-v1.yaml dist/llm-base.yaml; fi; cp .openapi/llm-v1.yaml dist/llm-head.yaml; ~/go/bin/oasdiff breaking --fail-on ERR dist/llm-base.yaml dist/llm-head.yaml'
- nix shell nixpkgs#go nixpkgs#gcc -c bash -c '~/go/bin/oapi-codegen --config oapi-codegen.server.yaml .openapi/team-v1.yaml; gofmt -w internal/gen/server.gen.go; git diff --exit-code internal/gen/server.gen.go'
- nix shell nixpkgs#go nixpkgs#gcc -c bash -c '~/go/bin/oapi-codegen --config oapi-codegen.llm.yaml .openapi/llm-v1.yaml; gofmt -w internal/llmgen/server.gen.go; git diff --exit-code internal/llmgen/server.gen.go'
- bash -c 'set -euo pipefail; bash scripts/sync-embedded-spec.sh; git diff --exit-code internal/apischema/teamv1/team-v1.yaml; git diff --exit-code internal/apischema/llmv1/llm-v1.yaml'
- nix shell nixpkgs#go nixpkgs#gcc -c go vet ./...
- nix shell nixpkgs#go nixpkgs#gcc -c go test ./...
- nix shell nixpkgs#nodejs -c bash -c 'set -euo pipefail; mkdir -p dist; npx --yes @redocly/cli build-docs .openapi/team-v1.yaml --output dist/redoc.html; npx --yes @redocly/cli build-docs .openapi/llm-v1.yaml --output dist/llm-redoc.html'

Refs #48