### PR TITLE
chore(buf): bust generate cache

### DIFF
--- a/buf.gen.yaml
+++ b/buf.gen.yaml
@@ -1,4 +1,5 @@
 version: v2
+# proto-update: teams-v1-variables-2026-03-13
 plugins:
   - remote: buf.build/protocolbuffers/go
     out: gen


### PR DESCRIPTION
## Summary
- add a cache-busting comment to buf.gen.yaml so Docker invalidates the buf generate layer

## Testing
- nix shell nixpkgs#nodejs -c npx --yes @stoplight/spectral-cli lint .openapi/team-v1.yaml .openapi/llm-v1.yaml
- bash -c 'set -euo pipefail
mkdir -p dist
git fetch origin main --depth=1 || true
if git rev-parse --verify origin/main >/dev/null 2>&1 && git cat-file -e origin/main:internal/apischema/teamv1/team-v1.yaml 2>/dev/null; then
  git show origin/main:internal/apischema/teamv1/team-v1.yaml > dist/base.yaml
else
  cp .openapi/team-v1.yaml dist/base.yaml
fi
cp .openapi/team-v1.yaml dist/head.yaml
/root/go/bin/oasdiff breaking --fail-on ERR dist/base.yaml dist/head.yaml
if git rev-parse --verify origin/main >/dev/null 2>&1 && git cat-file -e origin/main:internal/apischema/llmv1/llm-v1.yaml 2>/dev/null; then
  git show origin/main:internal/apischema/llmv1/llm-v1.yaml > dist/llm-base.yaml
else
  cp .openapi/llm-v1.yaml dist/llm-base.yaml
fi
cp .openapi/llm-v1.yaml dist/llm-head.yaml
/root/go/bin/oasdiff breaking --fail-on ERR dist/llm-base.yaml dist/llm-head.yaml
'
- nix shell nixpkgs#go nixpkgs#gcc -c go vet ./...
- nix shell nixpkgs#go nixpkgs#gcc -c go test ./...

Related Issue: #52