### PR TITLE
Simplify devspace config

### DIFF
--- a/devspace.yaml
+++ b/devspace.yaml
@@ -3,28 +3,24 @@ version: v2beta1
 vars:
   GATEWAY_NAMESPACE: platform
 
-functions:
-  disable_argocd_sync: |-
-    if kubectl get application gateway -n argocd >/dev/null 2>&1; then
-      echo "Disabling ArgoCD auto-sync for gateway..."
-      kubectl patch application gateway -n argocd \
-        --type merge \
-        -p '{"spec":{"syncPolicy":{"automated":null}}}'
-      echo "ArgoCD auto-sync disabled."
-    else
-      echo "WARNING: ArgoCD Application 'gateway' not found in argocd namespace."
-    fi
-  restore_argocd_sync: &restore_argocd_sync |-
-    if kubectl get application gateway -n argocd >/dev/null 2>&1; then
-      echo "Re-enabling ArgoCD auto-sync for gateway..."
-      kubectl patch application gateway -n argocd \
-        --type merge \
-        -p '{"spec":{"syncPolicy":{"automated":{"prune":true,"selfHeal":true}}}}'
-      echo "ArgoCD auto-sync restored."
-    fi
-  patch_deployment: |-
-    echo "Patching gateway deployment for DevSpace..."
-    kubectl patch deployment gateway-gateway -n ${GATEWAY_NAMESPACE} --type strategic --patch "$(cat <<'EOF'
+pipelines:
+  dev:
+    flags:
+      - name: no-logs
+        short: n
+        description: "Disable container log streaming"
+    run: |-
+      if kubectl get application gateway -n argocd >/dev/null 2>&1; then
+        echo "Disabling ArgoCD auto-sync for gateway..."
+        kubectl patch application gateway -n argocd \
+          --type merge \
+          -p '{"spec":{"syncPolicy":{"automated":null}}}'
+        echo "ArgoCD auto-sync disabled."
+      else
+        echo "WARNING: ArgoCD Application 'gateway' not found in argocd namespace."
+      fi
+      echo "Patching gateway deployment for DevSpace..."
+      kubectl patch deployment gateway-gateway -n ${GATEWAY_NAMESPACE} --type strategic --patch "$(cat <<'EOF'
       spec:
         template:
           spec:
@@ -72,47 +68,11 @@ functions:
                     type: RuntimeDefault
       EOF
       )"
-  wait_healthy: |-
-    echo "Waiting for gateway to be healthy on :8080..."
-    healthy=false
-    attempts=0
-    while [ "$attempts" -lt 60 ]; do
-      if exec_container --label-selector=app.kubernetes.io/name=gateway -n ${GATEWAY_NAMESPACE} -- bash -c 'nc -z localhost 8080 >/dev/null 2>&1 || (echo > /dev/tcp/localhost/8080) >/dev/null 2>&1'; then
-        healthy=true
-        break
-      fi
-      attempts=$((attempts + 1))
-      sleep 2
-    done
-    if [ "$healthy" = true ]; then
-      echo "Gateway is healthy on :8080."
-    else
-      echo "WARNING: Gateway did not become healthy on :8080 within 120s."
-    fi
-
-pipelines:
-  dev:
-    flags:
-      - name: no-logs
-        short: n
-        description: "Disable container log streaming"
-    run: |-
-      disable_argocd_sync
-      patch_deployment
       if [ "$(get_flag "no-logs")" == "true" ]; then
         start_dev --disable-pod-replace gateway --set containers.gateway.logs.enabled=false
       else
         start_dev --disable-pod-replace gateway
       fi
-
-  setup:
-    run: |-
-      disable_argocd_sync
-      trap 'restore_argocd_sync' EXIT
-      patch_deployment
-      wait_healthy
-      restore_argocd_sync
-      trap - EXIT
 
 hooks:
   - name: restore-argocd-auto-sync
@@ -121,7 +81,14 @@ hooks:
     command: sh
     args:
       - -c
-      - *restore_argocd_sync
+      - |
+        if kubectl get application gateway -n argocd >/dev/null 2>&1; then
+          echo "Re-enabling ArgoCD auto-sync for gateway..."
+          kubectl patch application gateway -n argocd \
+            --type merge \
+            -p '{"spec":{"syncPolicy":{"automated":{"prune":true,"selfHeal":true}}}}'
+          echo "ArgoCD auto-sync restored."
+        fi
 
 dev:
   gateway:


### PR DESCRIPTION
## Summary
- inline ArgoCD disable logic and deployment patching in the dev pipeline
- remove functions/setup pipeline and YAML anchors from devspace.yaml
- restore inline ArgoCD auto-sync hook with the original script

## Testing
- nix shell nixpkgs#buf -c buf generate buf.build/agynio/api --path agynio/api/files/v1 --path agynio/api/llm/v1 --path agynio/api/secrets/v1 --path agynio/api/teams/v1
- nix shell nixpkgs#nodejs -c npx --yes @stoplight/spectral-cli lint .openapi/team-v1.yaml
- nix shell nixpkgs#nodejs -c npx --yes @stoplight/spectral-cli lint .openapi/llm-v1.yaml
- bash -c 'set -euo pipefail
  mkdir -p dist
  git fetch origin main --depth=1 || true
  if git rev-parse --verify origin/main >/dev/null 2>&1 \
    && git cat-file -e origin/main:internal/apischema/teamv1/team-v1.yaml 2>/dev/null; then
    git show origin/main:internal/apischema/teamv1/team-v1.yaml > dist/base.yaml
  else
    cp .openapi/team-v1.yaml dist/base.yaml
  fi
  cp .openapi/team-v1.yaml dist/head.yaml
  /workspace/gateway/.bin/oasdiff breaking --fail-on ERR dist/base.yaml dist/head.yaml'
- bash -c 'set -euo pipefail
  mkdir -p dist
  git fetch origin main --depth=1 || true
  if git rev-parse --verify origin/main >/dev/null 2>&1 \
    && git cat-file -e origin/main:internal/apischema/llmv1/llm-v1.yaml 2>/dev/null; then
    git show origin/main:internal/apischema/llmv1/llm-v1.yaml > dist/llm-base.yaml
  else
    cp .openapi/llm-v1.yaml dist/llm-base.yaml
  fi
  cp .openapi/llm-v1.yaml dist/llm-head.yaml
  /workspace/gateway/.bin/oasdiff breaking --fail-on ERR dist/llm-base.yaml dist/llm-head.yaml'
- /workspace/gateway/.bin/oapi-codegen --config oapi-codegen.server.yaml .openapi/team-v1.yaml
- nix shell nixpkgs#go -c gofmt -w internal/gen/server.gen.go
- git diff --exit-code internal/gen/server.gen.go
- /workspace/gateway/.bin/oapi-codegen --config oapi-codegen.llm.yaml .openapi/llm-v1.yaml
- nix shell nixpkgs#go -c gofmt -w internal/llmgen/server.gen.go
- git diff --exit-code internal/llmgen/server.gen.go
- ./scripts/sync-embedded-spec.sh
- git diff --exit-code internal/apischema/teamv1/team-v1.yaml internal/apischema/llmv1/llm-v1.yaml
- nix shell nixpkgs#go nixpkgs#gcc -c go vet ./...
- nix shell nixpkgs#go nixpkgs#gcc -c go test ./...
- nix shell nixpkgs#nodejs -c npx --yes @redocly/cli build-docs .openapi/team-v1.yaml --output dist/redoc.html
- nix shell nixpkgs#nodejs -c npx --yes @redocly/cli build-docs .openapi/llm-v1.yaml --output dist/llm-redoc.html
- nix shell nixpkgs#kubernetes-helm -c helm dependency build charts/gateway
- nix shell nixpkgs#kubernetes-helm -c helm lint charts/gateway --set gateway.platformBaseUrl=https://platform.example.com

Closes #56