### PR TITLE
Fix devspace no-logs flag

### DIFF
--- a/devspace.yaml
+++ b/devspace.yaml
@@ -7,7 +7,6 @@ pipelines:
   dev:
     flags:
       - name: no-logs
-        short: n
         description: "Disable container log streaming"
     run: |-
       if kubectl get application gateway -n argocd >/dev/null 2>&1; then


### PR DESCRIPTION
## Summary
- remove the short `-n` alias from the `no-logs` devspace flag to avoid conflicts
- verified DevSpace CLI help/dev commands no longer panic

## Testing
- nix shell nixpkgs#devspace -c devspace dev --help
- nix shell nixpkgs#devspace -c timeout 20 devspace dev
- nix shell nixpkgs#devspace -c timeout 20 devspace dev --no-logs
- nix shell nixpkgs#buf -c buf generate buf.build/agynio/api --path agynio/api/files/v1 --path agynio/api/llm/v1 --path agynio/api/secrets/v1 --path agynio/api/teams/v1
- nix shell nixpkgs#nodejs -c npx --yes @stoplight/spectral-cli lint .openapi/team-v1.yaml
- nix shell nixpkgs#nodejs -c npx --yes @stoplight/spectral-cli lint .openapi/llm-v1.yaml
- bash -c 'set -euo pipefail
  mkdir -p dist
  git fetch origin main --depth=1 || true
  if git rev-parse --verify origin/main >/dev/null 2>&1 \
    && git cat-file -e origin/main:internal/apischema/teamv1/team-v1.yaml 2>/dev/null; then
    git show origin/main:internal/apischema/teamv1/team-v1.yaml > dist/base.yaml
  else
    cp .openapi/team-v1.yaml dist/base.yaml
  fi
  cp .openapi/team-v1.yaml dist/head.yaml
  /workspace/gateway-issue-58/.bin/oasdiff breaking --fail-on ERR dist/base.yaml dist/head.yaml'
- bash -c 'set -euo pipefail
  mkdir -p dist
  git fetch origin main --depth=1 || true
  if git rev-parse --verify origin/main >/dev/null 2>&1 \
    && git cat-file -e origin/main:internal/apischema/llmv1/llm-v1.yaml 2>/dev/null; then
    git show origin/main:internal/apischema/llmv1/llm-v1.yaml > dist/llm-base.yaml
  else
    cp .openapi/llm-v1.yaml dist/llm-base.yaml
  fi
  cp .openapi/llm-v1.yaml dist/llm-head.yaml
  /workspace/gateway-issue-58/.bin/oasdiff breaking --fail-on ERR dist/llm-base.yaml dist/llm-head.yaml'
- /workspace/gateway-issue-58/.bin/oapi-codegen --config oapi-codegen.server.yaml .openapi/team-v1.yaml
- nix shell nixpkgs#go -c gofmt -w internal/gen/server.gen.go
- git diff --exit-code internal/gen/server.gen.go
- /workspace/gateway-issue-58/.bin/oapi-codegen --config oapi-codegen.llm.yaml .openapi/llm-v1.yaml
- nix shell nixpkgs#go -c gofmt -w internal/llmgen/server.gen.go
- git diff --exit-code internal/llmgen/server.gen.go
- ./scripts/sync-embedded-spec.sh
- git diff --exit-code internal/apischema/teamv1/team-v1.yaml internal/apischema/llmv1/llm-v1.yaml
- nix shell nixpkgs#go nixpkgs#gcc -c go vet ./...
- nix shell nixpkgs#go nixpkgs#gcc -c go test ./...
- nix shell nixpkgs#nodejs -c npx --yes @redocly/cli build-docs .openapi/team-v1.yaml --output dist/redoc.html
- nix shell nixpkgs#nodejs -c npx --yes @redocly/cli build-docs .openapi/llm-v1.yaml --output dist/llm-redoc.html
- nix shell nixpkgs#kubernetes-helm -c helm dependency build charts/gateway
- nix shell nixpkgs#kubernetes-helm -c helm lint charts/gateway --set gateway.platformBaseUrl=https://platform.example.com

Closes #58