### PR TITLE
fix(devspace): add watch flag

### DIFF
--- a/devspace.yaml
+++ b/devspace.yaml
@@ -72,37 +72,31 @@ pipelines:
         start_dev --disable-pod-replace gateway
       else
         echo "Waiting for gateway to be healthy on :8080..."
+        healthy=false
         for i in $(seq 1 60); do
           if kubectl exec deployment/gateway-gateway -n ${GATEWAY_NAMESPACE} -c gateway -- bash -c 'nc -z localhost 8080 >/dev/null 2>&1 || (echo > /dev/tcp/localhost/8080) >/dev/null 2>&1' 2>/dev/null; then
             echo "Gateway is healthy on :8080."
+            healthy=true
             break
           fi
           sleep 2
         done
-        if kubectl get application gateway -n argocd >/dev/null 2>&1; then
-          echo "Re-enabling ArgoCD auto-sync for gateway..."
-          kubectl patch application gateway -n argocd \
-            --type merge \
-            -p '{"spec":{"syncPolicy":{"automated":{"prune":true,"selfHeal":true}}}}'
-          echo "ArgoCD auto-sync restored."
+        if [ "$healthy" != "true" ]; then
+          echo "ERROR: Gateway did not become healthy within 120s" >&2
+          exit 1
         fi
+        bash scripts/argocd-restore.sh
       fi
 
 hooks:
   - name: restore-argocd-auto-sync
     events:
       - after:dev:gateway
-    command: sh
+    command: bash
     args:
       - -c
       - |
-        if kubectl get application gateway -n argocd >/dev/null 2>&1; then
-          echo "Re-enabling ArgoCD auto-sync for gateway..."
-          kubectl patch application gateway -n argocd \
-            --type merge \
-            -p '{"spec":{"syncPolicy":{"automated":{"prune":true,"selfHeal":true}}}}'
-          echo "ArgoCD auto-sync restored."
-        fi
+        ./scripts/argocd-restore.sh
 
 dev:
   gateway:

--- a/scripts/argocd-restore.sh
+++ b/scripts/argocd-restore.sh
@@ -1,0 +1,10 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+if kubectl get application gateway -n argocd >/dev/null 2>&1; then
+  echo "Re-enabling ArgoCD auto-sync for gateway..."
+  kubectl patch application gateway -n argocd \
+    --type merge \
+    -p '{"spec":{"syncPolicy":{"automated":{"prune":true,"selfHeal":true}}}}'
+  echo "ArgoCD auto-sync restored."
+fi


### PR DESCRIPTION
## Summary
- replace no-logs flag with watch (-w) for dev pipeline
- add exit-mode health wait and inline ArgoCD restore when watch is off
- keep watch mode using start_dev and existing hooks

## Testing
- devspace dev --help
- timeout 20 devspace dev
- timeout 20 devspace dev -w
- ./scripts/pull-spec.sh
- nix shell nixpkgs#buf -c buf generate buf.build/agynio/api --template buf.gen.yaml --path agynio/api/files/v1 --path agynio/api/llm/v1 --path agynio/api/secrets/v1 --path agynio/api/teams/v1
- nix shell nixpkgs#nodejs -c npx --yes @stoplight/spectral-cli lint .openapi/team-v1.yaml
- nix shell nixpkgs#nodejs -c npx --yes @stoplight/spectral-cli lint .openapi/llm-v1.yaml
- bash -c 'set -euo pipefail; PATH=/root/go/bin:/root/.nix-profile/bin:/nix/var/nix/profiles/default/bin:/root/.nix-profile/bin:/nix/var/nix/profiles/default/bin:/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin; mkdir -p dist; git fetch origin main --depth=1 || true; if git rev-parse --verify origin/main >/dev/null 2>&1 && git cat-file -e origin/main:internal/apischema/teamv1/team-v1.yaml 2>/dev/null; then git show origin/main:internal/apischema/teamv1/team-v1.yaml > dist/base.yaml; else cp .openapi/team-v1.yaml dist/base.yaml; fi; cp .openapi/team-v1.yaml dist/head.yaml; oasdiff breaking --fail-on ERR dist/base.yaml dist/head.yaml'
- bash -c 'set -euo pipefail; PATH=/root/go/bin:/root/.nix-profile/bin:/nix/var/nix/profiles/default/bin:/root/.nix-profile/bin:/nix/var/nix/profiles/default/bin:/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin; mkdir -p dist; git fetch origin main --depth=1 || true; if git rev-parse --verify origin/main >/dev/null 2>&1 && git cat-file -e origin/main:internal/apischema/llmv1/llm-v1.yaml 2>/dev/null; then git show origin/main:internal/apischema/llmv1/llm-v1.yaml > dist/llm-base.yaml; else cp .openapi/llm-v1.yaml dist/llm-base.yaml; fi; cp .openapi/llm-v1.yaml dist/llm-head.yaml; oasdiff breaking --fail-on ERR dist/llm-base.yaml dist/llm-head.yaml'
- nix shell nixpkgs#go nixpkgs#gcc -c bash -c 'set -euo pipefail; PATH=/root/go/bin:/root/.nix-profile/bin:/nix/var/nix/profiles/default/bin:/root/.nix-profile/bin:/nix/var/nix/profiles/default/bin:/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin; oapi-codegen --config oapi-codegen.server.yaml .openapi/team-v1.yaml; gofmt -w internal/gen/server.gen.go; git diff --exit-code internal/gen/server.gen.go'
- nix shell nixpkgs#go nixpkgs#gcc -c bash -c 'set -euo pipefail; PATH=/root/go/bin:/root/.nix-profile/bin:/nix/var/nix/profiles/default/bin:/root/.nix-profile/bin:/nix/var/nix/profiles/default/bin:/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin; oapi-codegen --config oapi-codegen.llm.yaml .openapi/llm-v1.yaml; gofmt -w internal/llmgen/server.gen.go; git diff --exit-code internal/llmgen/server.gen.go'
- bash -c 'set -euo pipefail; bash scripts/sync-embedded-spec.sh; git diff --exit-code internal/apischema/teamv1/team-v1.yaml; git diff --exit-code internal/apischema/llmv1/llm-v1.yaml'
- nix shell nixpkgs#go nixpkgs#gcc -c go vet ./...
- nix shell nixpkgs#go nixpkgs#gcc -c go test ./...
- nix shell nixpkgs#nodejs -c bash -c 'set -euo pipefail; mkdir -p dist; npx --yes @redocly/cli build-docs .openapi/team-v1.yaml --output dist/redoc.html; npx --yes @redocly/cli build-docs .openapi/llm-v1.yaml --output dist/llm-redoc.html'

Closes #60