### PR TITLE
feat(gateway): expose chat service

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -50,7 +50,7 @@ jobs:
 
       - name: Generate gRPC stubs
         run: |
-          buf generate buf.build/agynio/api --path agynio/api/files/v1 --path agynio/api/llm/v1 --path agynio/api/secrets/v1 --path agynio/api/teams/v1 --path agynio/api/ziti_management/v1
+          buf generate buf.build/agynio/api --path agynio/api/chat/v1 --path agynio/api/files/v1 --path agynio/api/llm/v1 --path agynio/api/secrets/v1 --path agynio/api/teams/v1 --path agynio/api/ziti_management/v1
 
       - name: Generate OpenAPI code
         env:
@@ -71,6 +71,7 @@ jobs:
           mkdir -p dist
           redocly build-docs .openapi/team-v1.yaml --output dist/redoc.html
           redocly build-docs .openapi/llm-v1.yaml --output dist/llm-redoc.html
+          redocly build-docs .openapi/chat-v1.yaml --output dist/chat-redoc.html
 
       - name: Upload Redoc artifact
         uses: actions/upload-artifact@v4

--- a/.gitignore
+++ b/.gitignore
@@ -9,4 +9,5 @@ gateway.pid
 gen/
 internal/apischema/
 internal/gen/server.gen.go
+internal/chatgen/
 internal/llmgen/

--- a/Dockerfile
+++ b/Dockerfile
@@ -40,6 +40,7 @@ COPY scripts/ scripts/
 
 # Generate protobuf stubs
 RUN buf generate buf.build/agynio/api \
+      --path agynio/api/chat/v1 \
       --path agynio/api/files/v1 \
       --path agynio/api/llm/v1 \
       --path agynio/api/secrets/v1 \

--- a/charts/gateway/templates/_helpers.tpl
+++ b/charts/gateway/templates/_helpers.tpl
@@ -4,6 +4,9 @@
 {{- $teamsGrpcTarget := trimAll " \n\t" (default "" .Values.gateway.teamsGrpcTarget) -}}
 {{- $env = append $env (dict "name" "TEAMS_GRPC_TARGET" "value" $teamsGrpcTarget) -}}
 
+{{- $chatGrpcTarget := trimAll " \n\t" (default "" .Values.gateway.chatGrpcTarget) -}}
+{{- $env = append $env (dict "name" "CHAT_GRPC_TARGET" "value" $chatGrpcTarget) -}}
+
 {{- $filesGrpcTarget := trimAll " \n\t" (default "" .Values.gateway.filesGrpcTarget) -}}
 {{- $env = append $env (dict "name" "FILES_GRPC_TARGET" "value" $filesGrpcTarget) -}}
 

--- a/charts/gateway/values.yaml
+++ b/charts/gateway/values.yaml
@@ -152,6 +152,7 @@ metrics:
 
 gateway:
   teamsGrpcTarget: "teams:50051"
+  chatGrpcTarget: "chat:50051"
   filesGrpcTarget: "files:50051"
   llmGrpcTarget: "llm:50051"
   secretsGrpcTarget: "secrets:50051"

--- a/cmd/gateway/main.go
+++ b/cmd/gateway/main.go
@@ -20,8 +20,11 @@ import (
 	"github.com/openziti/sdk-golang/ziti"
 	"github.com/rs/cors"
 
+	chatv1schema "github.com/agynio/gateway/internal/apischema/chatv1"
 	llmv1schema "github.com/agynio/gateway/internal/apischema/llmv1"
 	teamv1schema "github.com/agynio/gateway/internal/apischema/teamv1"
+	"github.com/agynio/gateway/internal/chatclient"
+	"github.com/agynio/gateway/internal/chatgen"
 	"github.com/agynio/gateway/internal/filesclient"
 	"github.com/agynio/gateway/internal/gen"
 	"github.com/agynio/gateway/internal/handlers"
@@ -43,6 +46,11 @@ func main() {
 	teamSpec, err := loadTeamSpec()
 	if err != nil {
 		log.Fatalf("failed to load team OpenAPI spec: %v", err)
+	}
+
+	chatSpec, err := loadChatSpec()
+	if err != nil {
+		log.Fatalf("failed to load chat OpenAPI spec: %v", err)
 	}
 
 	config, err := platform.LoadConfigFromEnv()
@@ -70,6 +78,16 @@ func main() {
 	defer func() {
 		if err := teamsClient.Close(); err != nil {
 			log.Printf("failed to close teams gRPC client: %v", err)
+		}
+	}()
+
+	chatClient, err := chatclient.NewClient(config.ChatGRPCTarget)
+	if err != nil {
+		log.Fatalf("failed to create chat gRPC client: %v", err)
+	}
+	defer func() {
+		if err := chatClient.Close(); err != nil {
+			log.Printf("failed to close chat gRPC client: %v", err)
 		}
 	}()
 
@@ -115,6 +133,30 @@ func main() {
 	gen.HandlerWithOptions(strictHandler, gen.ChiServerOptions{BaseRouter: teamRouter})
 
 	root.Mount(handlers.TeamBasePath(), teamRouter)
+
+	chatRouter := chi.NewRouter()
+
+	chatRequestValidator, err := handlers.NewRequestValidationMiddleware(chatSpec)
+	if err != nil {
+		log.Fatalf("failed to initialise chat request validation: %v", err)
+	}
+	chatRouter.Use(chatRequestValidator)
+
+	if isResponseValidationEnabled() {
+		responseValidator, err := handlers.NewResponseValidationMiddleware(chatSpec)
+		if err != nil {
+			log.Fatalf("failed to initialise chat response validation: %v", err)
+		}
+		chatRouter.Use(responseValidator)
+	}
+
+	chatStrictHandler := chatgen.NewStrictHandlerWithOptions(handlers.NewChatHandler(chatClient.ChatServiceClient()), nil, chatgen.StrictHTTPServerOptions{
+		RequestErrorHandlerFunc:  handlers.StrictRequestErrorHandler,
+		ResponseErrorHandlerFunc: handlers.StrictErrorHandler,
+	})
+	chatgen.HandlerWithOptions(chatStrictHandler, chatgen.ChiServerOptions{BaseRouter: chatRouter})
+
+	root.Mount(handlers.ChatBasePath(), chatRouter)
 
 	filesClient, err := filesclient.NewClient(config.FilesGRPCTarget)
 	if err != nil {
@@ -269,6 +311,15 @@ func loadLLMSpec() (*openapi3.T, error) {
 		return nil, err
 	}
 	swagger.Servers = []*openapi3.Server{{URL: handlers.LLMBasePath()}}
+	return swagger, nil
+}
+
+func loadChatSpec() (*openapi3.T, error) {
+	swagger, err := chatv1schema.LoadSpec()
+	if err != nil {
+		return nil, err
+	}
+	swagger.Servers = []*openapi3.Server{{URL: handlers.ChatBasePath()}}
 	return swagger, nil
 }
 

--- a/devspace.yaml
+++ b/devspace.yaml
@@ -151,6 +151,7 @@ dev:
               - .devspace/
               - /internal/apischema/
               - /internal/gen/server.gen.go
+              - /internal/chatgen/
               - /internal/llmgen/
               - gateway.log
               - gateway.pid
@@ -161,6 +162,7 @@ dev:
               - dist/
               - /internal/apischema/
               - /internal/gen/server.gen.go
+              - /internal/chatgen/
               - /internal/llmgen/
             downloadExcludePaths:
               - .git/
@@ -169,6 +171,7 @@ dev:
               - dist/
               - /internal/apischema/
               - /internal/gen/server.gen.go
+              - /internal/chatgen/
               - /internal/llmgen/
         logs:
           enabled: true

--- a/internal/chatclient/client.go
+++ b/internal/chatclient/client.go
@@ -1,0 +1,40 @@
+package chatclient
+
+import (
+	"fmt"
+	"strings"
+
+	chatv1 "github.com/agynio/gateway/gen/agynio/api/chat/v1"
+	"google.golang.org/grpc"
+	"google.golang.org/grpc/credentials/insecure"
+)
+
+// Client wraps the Chat gRPC connection and client.
+type Client struct {
+	conn   *grpc.ClientConn
+	client chatv1.ChatServiceClient
+}
+
+func NewClient(target string) (*Client, error) {
+	if strings.TrimSpace(target) == "" {
+		return nil, fmt.Errorf("target is required")
+	}
+
+	conn, err := grpc.NewClient(target, grpc.WithTransportCredentials(insecure.NewCredentials()))
+	if err != nil {
+		return nil, err
+	}
+
+	return &Client{
+		conn:   conn,
+		client: chatv1.NewChatServiceClient(conn),
+	}, nil
+}
+
+func (c *Client) Close() error {
+	return c.conn.Close()
+}
+
+func (c *Client) ChatServiceClient() chatv1.ChatServiceClient {
+	return c.client
+}

--- a/internal/handlers/chat.go
+++ b/internal/handlers/chat.go
@@ -1,0 +1,147 @@
+package handlers
+
+import (
+	"context"
+	"fmt"
+
+	chatv1 "github.com/agynio/gateway/gen/agynio/api/chat/v1"
+	"github.com/agynio/gateway/internal/chatgen"
+)
+
+const chatBasePath = "/chat/v1"
+
+func ChatBasePath() string {
+	return chatBasePath
+}
+
+// ChatHandler implements chatgen.StrictServerInterface for the Chat API.
+type ChatHandler struct {
+	client chatv1.ChatServiceClient
+}
+
+func NewChatHandler(client chatv1.ChatServiceClient) *ChatHandler {
+	if client == nil {
+		panic("chat client is required")
+	}
+	return &ChatHandler{client: client}
+}
+
+var _ chatgen.StrictServerInterface = (*ChatHandler)(nil)
+
+func (h *ChatHandler) GetChats(ctx context.Context, request chatgen.GetChatsRequestObject) (chatgen.GetChatsResponseObject, error) {
+	resp, err := h.client.GetChats(ctx, &chatv1.GetChatsRequest{
+		PageSize:  pageSizeFromParam(request.Params.PageSize),
+		PageToken: stringValue(request.Params.PageToken),
+	})
+	if err != nil {
+		return nil, grpcErrorToProblem(err)
+	}
+
+	items := make([]chatgen.Chat, 0, len(resp.GetChats()))
+	for _, chat := range resp.GetChats() {
+		converted, err := chatFromProto(chat)
+		if err != nil {
+			return nil, responseProblem(err)
+		}
+		items = append(items, converted)
+	}
+
+	payload := chatgen.PaginatedChats{
+		Items:         items,
+		NextPageToken: stringPtr(resp.GetNextPageToken()),
+	}
+
+	return chatgen.GetChats200JSONResponse(payload), nil
+}
+
+func (h *ChatHandler) CreateChat(ctx context.Context, request chatgen.CreateChatRequestObject) (chatgen.CreateChatResponseObject, error) {
+	if request.Body == nil {
+		panic("validated request body is unexpectedly nil")
+	}
+
+	resp, err := h.client.CreateChat(ctx, chatCreateToProto(*request.Body))
+	if err != nil {
+		return nil, grpcErrorToProblem(err)
+	}
+
+	chat := resp.GetChat()
+	if chat == nil {
+		return nil, responseProblem(fmt.Errorf("create chat response missing chat"))
+	}
+
+	converted, err := chatFromProto(chat)
+	if err != nil {
+		return nil, responseProblem(err)
+	}
+
+	return chatgen.CreateChat201JSONResponse(converted), nil
+}
+
+func (h *ChatHandler) GetChatMessages(ctx context.Context, request chatgen.GetChatMessagesRequestObject) (chatgen.GetChatMessagesResponseObject, error) {
+	resp, err := h.client.GetMessages(ctx, &chatv1.GetMessagesRequest{
+		ChatId:    request.ChatId.String(),
+		PageSize:  pageSizeFromParam(request.Params.PageSize),
+		PageToken: stringValue(request.Params.PageToken),
+	})
+	if err != nil {
+		return nil, grpcErrorToProblem(err)
+	}
+
+	items, err := chatMessagesFromProto(resp.GetMessages())
+	if err != nil {
+		return nil, responseProblem(err)
+	}
+
+	payload := chatgen.PaginatedChatMessages{
+		Items:         items,
+		NextPageToken: stringPtr(resp.GetNextPageToken()),
+		UnreadCount:   int(resp.GetUnreadCount()),
+	}
+
+	return chatgen.GetChatMessages200JSONResponse(payload), nil
+}
+
+func (h *ChatHandler) SendChatMessage(ctx context.Context, request chatgen.SendChatMessageRequestObject) (chatgen.SendChatMessageResponseObject, error) {
+	if request.Body == nil {
+		panic("validated request body is unexpectedly nil")
+	}
+
+	messageRequest, err := chatMessageCreateToProto(request.ChatId, *request.Body)
+	if err != nil {
+		return nil, requestProblem(err)
+	}
+
+	resp, err := h.client.SendMessage(ctx, messageRequest)
+	if err != nil {
+		return nil, grpcErrorToProblem(err)
+	}
+
+	message := resp.GetMessage()
+	if message == nil {
+		return nil, responseProblem(fmt.Errorf("send message response missing message"))
+	}
+
+	converted, err := chatMessageFromProto(message)
+	if err != nil {
+		return nil, responseProblem(err)
+	}
+
+	return chatgen.SendChatMessage201JSONResponse(converted), nil
+}
+
+func (h *ChatHandler) MarkChatAsRead(ctx context.Context, request chatgen.MarkChatAsReadRequestObject) (chatgen.MarkChatAsReadResponseObject, error) {
+	if request.Body == nil {
+		panic("validated request body is unexpectedly nil")
+	}
+
+	resp, err := h.client.MarkAsRead(ctx, markAsReadToProto(request.ChatId, *request.Body))
+	if err != nil {
+		return nil, grpcErrorToProblem(err)
+	}
+
+	payload := chatgen.MarkAsReadResponse{
+		ReadCount: int(resp.GetReadCount()),
+	}
+
+	return chatgen.MarkChatAsRead200JSONResponse(payload), nil
+}

--- a/internal/handlers/chat_convert.go
+++ b/internal/handlers/chat_convert.go
@@ -1,0 +1,190 @@
+package handlers
+
+import (
+	"fmt"
+	"time"
+
+	openapi_types "github.com/oapi-codegen/runtime/types"
+
+	chatv1 "github.com/agynio/gateway/gen/agynio/api/chat/v1"
+	"github.com/agynio/gateway/internal/chatgen"
+)
+
+func chatFromProto(chat *chatv1.Chat) (chatgen.Chat, error) {
+	if chat == nil {
+		return chatgen.Chat{}, fmt.Errorf("chat missing")
+	}
+
+	chatID, err := parseUUID(chat.GetId())
+	if err != nil {
+		return chatgen.Chat{}, fmt.Errorf("parse chat id: %w", err)
+	}
+
+	participants, err := chatParticipantsFromProto(chat.GetParticipants())
+	if err != nil {
+		return chatgen.Chat{}, err
+	}
+
+	createdAt := chat.GetCreatedAt()
+	if createdAt == nil {
+		return chatgen.Chat{}, fmt.Errorf("chat created_at missing")
+	}
+
+	var updatedAt *time.Time
+	if updated := chat.GetUpdatedAt(); updated != nil {
+		value := updated.AsTime().UTC()
+		updatedAt = &value
+	}
+
+	return chatgen.Chat{
+		Id:           chatID,
+		Participants: participants,
+		CreatedAt:    createdAt.AsTime().UTC(),
+		UpdatedAt:    updatedAt,
+	}, nil
+}
+
+func chatParticipantsFromProto(participants []*chatv1.ChatParticipant) ([]chatgen.ChatParticipant, error) {
+	if len(participants) == 0 {
+		return []chatgen.ChatParticipant{}, nil
+	}
+
+	items := make([]chatgen.ChatParticipant, 0, len(participants))
+	for _, participant := range participants {
+		converted, err := chatParticipantFromProto(participant)
+		if err != nil {
+			return nil, err
+		}
+		items = append(items, converted)
+	}
+
+	return items, nil
+}
+
+func chatParticipantFromProto(participant *chatv1.ChatParticipant) (chatgen.ChatParticipant, error) {
+	if participant == nil {
+		return chatgen.ChatParticipant{}, fmt.Errorf("chat participant missing")
+	}
+
+	participantID, err := parseUUID(participant.GetId())
+	if err != nil {
+		return chatgen.ChatParticipant{}, fmt.Errorf("parse participant id: %w", err)
+	}
+
+	joinedAt := participant.GetJoinedAt()
+	if joinedAt == nil {
+		return chatgen.ChatParticipant{}, fmt.Errorf("participant joined_at missing")
+	}
+
+	return chatgen.ChatParticipant{
+		Id:       participantID,
+		JoinedAt: joinedAt.AsTime().UTC(),
+	}, nil
+}
+
+func chatMessageFromProto(message *chatv1.ChatMessage) (chatgen.ChatMessage, error) {
+	if message == nil {
+		return chatgen.ChatMessage{}, fmt.Errorf("chat message missing")
+	}
+
+	messageID, err := parseUUID(message.GetId())
+	if err != nil {
+		return chatgen.ChatMessage{}, fmt.Errorf("parse message id: %w", err)
+	}
+
+	chatID, err := parseUUID(message.GetChatId())
+	if err != nil {
+		return chatgen.ChatMessage{}, fmt.Errorf("parse chat id: %w", err)
+	}
+
+	senderID, err := parseUUID(message.GetSenderId())
+	if err != nil {
+		return chatgen.ChatMessage{}, fmt.Errorf("parse sender id: %w", err)
+	}
+
+	fileIDs, err := uuidSliceFromStrings(message.GetFileIds())
+	if err != nil {
+		return chatgen.ChatMessage{}, fmt.Errorf("parse file ids: %w", err)
+	}
+
+	createdAt := message.GetCreatedAt()
+	if createdAt == nil {
+		return chatgen.ChatMessage{}, fmt.Errorf("message created_at missing")
+	}
+
+	return chatgen.ChatMessage{
+		Id:        messageID,
+		ChatId:    chatID,
+		SenderId:  senderID,
+		Body:      message.GetBody(),
+		FileIds:   fileIDs,
+		CreatedAt: createdAt.AsTime().UTC(),
+	}, nil
+}
+
+func chatMessagesFromProto(messages []*chatv1.ChatMessage) ([]chatgen.ChatMessage, error) {
+	if len(messages) == 0 {
+		return []chatgen.ChatMessage{}, nil
+	}
+
+	items := make([]chatgen.ChatMessage, 0, len(messages))
+	for _, message := range messages {
+		converted, err := chatMessageFromProto(message)
+		if err != nil {
+			return nil, err
+		}
+		items = append(items, converted)
+	}
+
+	return items, nil
+}
+
+func chatCreateToProto(request chatgen.ChatCreateRequest) *chatv1.CreateChatRequest {
+	return &chatv1.CreateChatRequest{
+		ParticipantIds: uuidSliceToStrings(request.ParticipantIds),
+	}
+}
+
+func chatMessageCreateToProto(chatID openapi_types.UUID, request chatgen.ChatMessageCreateRequest) (*chatv1.SendMessageRequest, error) {
+	body := stringValue(request.Body)
+	fileIDs := []string{}
+	if request.FileIds != nil {
+		fileIDs = uuidSliceToStrings(*request.FileIds)
+	}
+	if body == "" && len(fileIDs) == 0 {
+		return nil, fmt.Errorf("message body or fileIds required")
+	}
+
+	return &chatv1.SendMessageRequest{
+		ChatId:  chatID.String(),
+		Body:    body,
+		FileIds: fileIDs,
+	}, nil
+}
+
+func markAsReadToProto(chatID openapi_types.UUID, request chatgen.MarkAsReadRequest) *chatv1.MarkAsReadRequest {
+	return &chatv1.MarkAsReadRequest{
+		ChatId:     chatID.String(),
+		MessageIds: uuidSliceToStrings(request.MessageIds),
+	}
+}
+
+func uuidSliceFromStrings(values []string) ([]openapi_types.UUID, error) {
+	items := make([]openapi_types.UUID, 0, len(values))
+	for _, value := range values {
+		parsed, err := parseUUID(value)
+		if err != nil {
+			return nil, err
+		}
+		items = append(items, parsed)
+	}
+	return items, nil
+}
+
+func uuidSliceToStrings(values []openapi_types.UUID) []string {
+	items := make([]string, 0, len(values))
+	for _, value := range values {
+		items = append(items, value.String())
+	}
+	return items
+}

--- a/internal/handlers/chat_test.go
+++ b/internal/handlers/chat_test.go
@@ -1,0 +1,418 @@
+package handlers
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"github.com/google/uuid"
+	openapi_types "github.com/oapi-codegen/runtime/types"
+	"google.golang.org/grpc"
+	"google.golang.org/protobuf/types/known/timestamppb"
+
+	chatv1 "github.com/agynio/gateway/gen/agynio/api/chat/v1"
+	"github.com/agynio/gateway/internal/chatgen"
+)
+
+type chatCall struct {
+	method string
+	assert func(any)
+	resp   any
+	err    error
+}
+
+type stubChatClient struct {
+	t     *testing.T
+	calls []chatCall
+	idx   int
+}
+
+func (s *stubChatClient) Expect(call chatCall) {
+	s.calls = append(s.calls, call)
+}
+
+func (s *stubChatClient) AssertDone() {
+	if s.idx != len(s.calls) {
+		s.t.Fatalf("expected %d calls, got %d", len(s.calls), s.idx)
+	}
+}
+
+func (s *stubChatClient) nextCall(method string, req any) chatCall {
+	if s.idx >= len(s.calls) {
+		s.t.Fatalf("unexpected call %s", method)
+	}
+	call := s.calls[s.idx]
+	s.idx++
+	if call.method != method {
+		s.t.Fatalf("unexpected method: got %s want %s", method, call.method)
+	}
+	if call.assert != nil {
+		call.assert(req)
+	}
+	return call
+}
+
+func (s *stubChatClient) CreateChat(ctx context.Context, req *chatv1.CreateChatRequest, _ ...grpc.CallOption) (*chatv1.CreateChatResponse, error) {
+	call := s.nextCall("CreateChat", req)
+	resp, ok := call.resp.(*chatv1.CreateChatResponse)
+	if call.resp != nil && !ok {
+		s.t.Fatalf("unexpected response type: %T", call.resp)
+	}
+	return resp, call.err
+}
+
+func (s *stubChatClient) GetChats(ctx context.Context, req *chatv1.GetChatsRequest, _ ...grpc.CallOption) (*chatv1.GetChatsResponse, error) {
+	call := s.nextCall("GetChats", req)
+	resp, ok := call.resp.(*chatv1.GetChatsResponse)
+	if call.resp != nil && !ok {
+		s.t.Fatalf("unexpected response type: %T", call.resp)
+	}
+	return resp, call.err
+}
+
+func (s *stubChatClient) GetMessages(ctx context.Context, req *chatv1.GetMessagesRequest, _ ...grpc.CallOption) (*chatv1.GetMessagesResponse, error) {
+	call := s.nextCall("GetMessages", req)
+	resp, ok := call.resp.(*chatv1.GetMessagesResponse)
+	if call.resp != nil && !ok {
+		s.t.Fatalf("unexpected response type: %T", call.resp)
+	}
+	return resp, call.err
+}
+
+func (s *stubChatClient) SendMessage(ctx context.Context, req *chatv1.SendMessageRequest, _ ...grpc.CallOption) (*chatv1.SendMessageResponse, error) {
+	call := s.nextCall("SendMessage", req)
+	resp, ok := call.resp.(*chatv1.SendMessageResponse)
+	if call.resp != nil && !ok {
+		s.t.Fatalf("unexpected response type: %T", call.resp)
+	}
+	return resp, call.err
+}
+
+func (s *stubChatClient) MarkAsRead(ctx context.Context, req *chatv1.MarkAsReadRequest, _ ...grpc.CallOption) (*chatv1.MarkAsReadResponse, error) {
+	call := s.nextCall("MarkAsRead", req)
+	resp, ok := call.resp.(*chatv1.MarkAsReadResponse)
+	if call.resp != nil && !ok {
+		s.t.Fatalf("unexpected response type: %T", call.resp)
+	}
+	return resp, call.err
+}
+
+func TestChatGetChats(t *testing.T) {
+	stub := &stubChatClient{t: t}
+	chatID := uuid.MustParse("11111111-1111-1111-1111-111111111111")
+	participantID := uuid.MustParse("22222222-2222-2222-2222-222222222222")
+	createdAt := time.Date(2024, 1, 2, 3, 4, 5, 0, time.UTC)
+	joinedAt := time.Date(2024, 1, 2, 3, 4, 6, 0, time.UTC)
+	updatedAt := time.Date(2024, 1, 3, 4, 5, 6, 0, time.UTC)
+
+	stub.Expect(chatCall{
+		method: "GetChats",
+		assert: func(req any) {
+			input := req.(*chatv1.GetChatsRequest)
+			if input.PageSize != 5 {
+				t.Fatalf("unexpected page size: %d", input.PageSize)
+			}
+			if input.PageToken != "cursor" {
+				t.Fatalf("unexpected page token: %s", input.PageToken)
+			}
+		},
+		resp: &chatv1.GetChatsResponse{
+			Chats: []*chatv1.Chat{
+				{
+					Id: chatID.String(),
+					Participants: []*chatv1.ChatParticipant{
+						{Id: participantID.String(), JoinedAt: timestamppb.New(joinedAt)},
+					},
+					CreatedAt: timestamppb.New(createdAt),
+					UpdatedAt: timestamppb.New(updatedAt),
+				},
+			},
+			NextPageToken: "next",
+		},
+	})
+
+	pageSize := 5
+	pageToken := "cursor"
+	h := NewChatHandler(stub)
+	resp, err := h.GetChats(context.Background(), chatgen.GetChatsRequestObject{Params: chatgen.GetChatsParams{
+		PageSize:  &pageSize,
+		PageToken: &pageToken,
+	}})
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	list, ok := resp.(chatgen.GetChats200JSONResponse)
+	if !ok {
+		t.Fatalf("unexpected response type: %T", resp)
+	}
+	if list.NextPageToken == nil || *list.NextPageToken != "next" {
+		t.Fatalf("unexpected next page token: %v", list.NextPageToken)
+	}
+	if len(list.Items) != 1 {
+		t.Fatalf("expected 1 chat, got %d", len(list.Items))
+	}
+	item := list.Items[0]
+	if item.Id != openapi_types.UUID(chatID) {
+		t.Fatalf("unexpected chat id: %s", item.Id.String())
+	}
+	if !item.CreatedAt.Equal(createdAt) {
+		t.Fatalf("unexpected createdAt: %v", item.CreatedAt)
+	}
+	if item.UpdatedAt == nil || !item.UpdatedAt.Equal(updatedAt) {
+		t.Fatalf("unexpected updatedAt: %v", item.UpdatedAt)
+	}
+	if len(item.Participants) != 1 {
+		t.Fatalf("expected 1 participant, got %d", len(item.Participants))
+	}
+	participant := item.Participants[0]
+	if participant.Id != openapi_types.UUID(participantID) {
+		t.Fatalf("unexpected participant id: %s", participant.Id.String())
+	}
+	if !participant.JoinedAt.Equal(joinedAt) {
+		t.Fatalf("unexpected joinedAt: %v", participant.JoinedAt)
+	}
+
+	stub.AssertDone()
+}
+
+func TestChatCreateChat(t *testing.T) {
+	stub := &stubChatClient{t: t}
+	chatID := uuid.MustParse("33333333-3333-3333-3333-333333333333")
+	participantID := uuid.MustParse("44444444-4444-4444-4444-444444444444")
+	createdAt := time.Date(2024, 5, 6, 7, 8, 9, 0, time.UTC)
+
+	stub.Expect(chatCall{
+		method: "CreateChat",
+		assert: func(req any) {
+			input := req.(*chatv1.CreateChatRequest)
+			if len(input.ParticipantIds) != 1 || input.ParticipantIds[0] != participantID.String() {
+				t.Fatalf("unexpected participant ids: %v", input.ParticipantIds)
+			}
+		},
+		resp: &chatv1.CreateChatResponse{
+			Chat: &chatv1.Chat{
+				Id: chatID.String(),
+				Participants: []*chatv1.ChatParticipant{
+					{Id: participantID.String(), JoinedAt: timestamppb.New(createdAt)},
+				},
+				CreatedAt: timestamppb.New(createdAt),
+			},
+		},
+	})
+
+	request := chatgen.CreateChatRequestObject{Body: &chatgen.ChatCreateRequest{
+		ParticipantIds: []openapi_types.UUID{openapi_types.UUID(participantID)},
+	}}
+
+	h := NewChatHandler(stub)
+	resp, err := h.CreateChat(context.Background(), request)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	created, ok := resp.(chatgen.CreateChat201JSONResponse)
+	if !ok {
+		t.Fatalf("unexpected response type: %T", resp)
+	}
+	if created.Id != openapi_types.UUID(chatID) {
+		t.Fatalf("unexpected chat id: %s", created.Id.String())
+	}
+	if len(created.Participants) != 1 {
+		t.Fatalf("expected 1 participant, got %d", len(created.Participants))
+	}
+
+	stub.AssertDone()
+}
+
+func TestChatGetMessages(t *testing.T) {
+	stub := &stubChatClient{t: t}
+	chatID := uuid.MustParse("55555555-5555-5555-5555-555555555555")
+	messageID := uuid.MustParse("66666666-6666-6666-6666-666666666666")
+	senderID := uuid.MustParse("77777777-7777-7777-7777-777777777777")
+	fileID := uuid.MustParse("88888888-8888-8888-8888-888888888888")
+	createdAt := time.Date(2024, 7, 8, 9, 10, 11, 0, time.UTC)
+
+	stub.Expect(chatCall{
+		method: "GetMessages",
+		assert: func(req any) {
+			input := req.(*chatv1.GetMessagesRequest)
+			if input.ChatId != chatID.String() {
+				t.Fatalf("unexpected chat id: %s", input.ChatId)
+			}
+			if input.PageSize != 3 {
+				t.Fatalf("unexpected page size: %d", input.PageSize)
+			}
+			if input.PageToken != "token" {
+				t.Fatalf("unexpected page token: %s", input.PageToken)
+			}
+		},
+		resp: &chatv1.GetMessagesResponse{
+			Messages: []*chatv1.ChatMessage{
+				{
+					Id:        messageID.String(),
+					ChatId:    chatID.String(),
+					SenderId:  senderID.String(),
+					Body:      "hello",
+					FileIds:   []string{fileID.String()},
+					CreatedAt: timestamppb.New(createdAt),
+				},
+			},
+			NextPageToken: "next",
+			UnreadCount:   2,
+		},
+	})
+
+	pageSize := 3
+	pageToken := "token"
+	h := NewChatHandler(stub)
+	resp, err := h.GetChatMessages(context.Background(), chatgen.GetChatMessagesRequestObject{
+		ChatId: openapi_types.UUID(chatID),
+		Params: chatgen.GetChatMessagesParams{PageSize: &pageSize, PageToken: &pageToken},
+	})
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	list, ok := resp.(chatgen.GetChatMessages200JSONResponse)
+	if !ok {
+		t.Fatalf("unexpected response type: %T", resp)
+	}
+	if list.UnreadCount != 2 {
+		t.Fatalf("unexpected unread count: %d", list.UnreadCount)
+	}
+	if list.NextPageToken == nil || *list.NextPageToken != "next" {
+		t.Fatalf("unexpected next page token: %v", list.NextPageToken)
+	}
+	if len(list.Items) != 1 {
+		t.Fatalf("expected 1 message, got %d", len(list.Items))
+	}
+	message := list.Items[0]
+	if message.Id != openapi_types.UUID(messageID) {
+		t.Fatalf("unexpected message id: %s", message.Id.String())
+	}
+	if message.ChatId != openapi_types.UUID(chatID) {
+		t.Fatalf("unexpected chat id: %s", message.ChatId.String())
+	}
+	if message.SenderId != openapi_types.UUID(senderID) {
+		t.Fatalf("unexpected sender id: %s", message.SenderId.String())
+	}
+	if message.Body != "hello" {
+		t.Fatalf("unexpected body: %s", message.Body)
+	}
+	if len(message.FileIds) != 1 || message.FileIds[0] != openapi_types.UUID(fileID) {
+		t.Fatalf("unexpected file ids: %v", message.FileIds)
+	}
+	if !message.CreatedAt.Equal(createdAt) {
+		t.Fatalf("unexpected createdAt: %v", message.CreatedAt)
+	}
+
+	stub.AssertDone()
+}
+
+func TestChatSendMessage(t *testing.T) {
+	stub := &stubChatClient{t: t}
+	chatID := uuid.MustParse("99999999-9999-9999-9999-999999999999")
+	messageID := uuid.MustParse("aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaa")
+	senderID := uuid.MustParse("bbbbbbbb-bbbb-bbbb-bbbb-bbbbbbbbbbbb")
+	fileID := uuid.MustParse("cccccccc-cccc-cccc-cccc-cccccccccccc")
+	createdAt := time.Date(2024, 8, 9, 10, 11, 12, 0, time.UTC)
+	body := "ping"
+	fileIDs := []openapi_types.UUID{openapi_types.UUID(fileID)}
+
+	stub.Expect(chatCall{
+		method: "SendMessage",
+		assert: func(req any) {
+			input := req.(*chatv1.SendMessageRequest)
+			if input.ChatId != chatID.String() {
+				t.Fatalf("unexpected chat id: %s", input.ChatId)
+			}
+			if input.Body != body {
+				t.Fatalf("unexpected body: %s", input.Body)
+			}
+			if len(input.FileIds) != 1 || input.FileIds[0] != fileID.String() {
+				t.Fatalf("unexpected file ids: %v", input.FileIds)
+			}
+		},
+		resp: &chatv1.SendMessageResponse{
+			Message: &chatv1.ChatMessage{
+				Id:        messageID.String(),
+				ChatId:    chatID.String(),
+				SenderId:  senderID.String(),
+				Body:      body,
+				FileIds:   []string{fileID.String()},
+				CreatedAt: timestamppb.New(createdAt),
+			},
+		},
+	})
+
+	request := chatgen.SendChatMessageRequestObject{
+		ChatId: openapi_types.UUID(chatID),
+		Body: &chatgen.ChatMessageCreateRequest{
+			Body:    &body,
+			FileIds: &fileIDs,
+		},
+	}
+
+	h := NewChatHandler(stub)
+	resp, err := h.SendChatMessage(context.Background(), request)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	created, ok := resp.(chatgen.SendChatMessage201JSONResponse)
+	if !ok {
+		t.Fatalf("unexpected response type: %T", resp)
+	}
+	if created.Id != openapi_types.UUID(messageID) {
+		t.Fatalf("unexpected message id: %s", created.Id.String())
+	}
+	if len(created.FileIds) != 1 || created.FileIds[0] != openapi_types.UUID(fileID) {
+		t.Fatalf("unexpected file ids: %v", created.FileIds)
+	}
+
+	stub.AssertDone()
+}
+
+func TestChatMarkAsRead(t *testing.T) {
+	stub := &stubChatClient{t: t}
+	chatID := uuid.MustParse("dddddddd-dddd-dddd-dddd-dddddddddddd")
+	messageID := uuid.MustParse("eeeeeeee-eeee-eeee-eeee-eeeeeeeeeeee")
+
+	stub.Expect(chatCall{
+		method: "MarkAsRead",
+		assert: func(req any) {
+			input := req.(*chatv1.MarkAsReadRequest)
+			if input.ChatId != chatID.String() {
+				t.Fatalf("unexpected chat id: %s", input.ChatId)
+			}
+			if len(input.MessageIds) != 1 || input.MessageIds[0] != messageID.String() {
+				t.Fatalf("unexpected message ids: %v", input.MessageIds)
+			}
+		},
+		resp: &chatv1.MarkAsReadResponse{ReadCount: 1},
+	})
+
+	request := chatgen.MarkChatAsReadRequestObject{
+		ChatId: openapi_types.UUID(chatID),
+		Body: &chatgen.MarkAsReadRequest{
+			MessageIds: []openapi_types.UUID{openapi_types.UUID(messageID)},
+		},
+	}
+
+	h := NewChatHandler(stub)
+	resp, err := h.MarkChatAsRead(context.Background(), request)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	ack, ok := resp.(chatgen.MarkChatAsRead200JSONResponse)
+	if !ok {
+		t.Fatalf("unexpected response type: %T", resp)
+	}
+	if ack.ReadCount != 1 {
+		t.Fatalf("unexpected read count: %d", ack.ReadCount)
+	}
+
+	stub.AssertDone()
+}

--- a/internal/platform/config.go
+++ b/internal/platform/config.go
@@ -7,6 +7,7 @@ import (
 
 const (
 	defaultTeamsGRPCTarget          = "teams:50051"
+	defaultChatGRPCTarget           = "chat:50051"
 	defaultFilesGRPCTarget          = "files:50051"
 	defaultLLMGRPCTarget            = "llm:50051"
 	defaultSecretsGRPCTarget        = "secrets:50051"
@@ -16,6 +17,7 @@ const (
 // Config holds the runtime configuration for communicating with upstream services.
 type Config struct {
 	TeamsGRPCTarget          string
+	ChatGRPCTarget           string
 	FilesGRPCTarget          string
 	LLMGRPCTarget            string
 	SecretsGRPCTarget        string
@@ -27,6 +29,7 @@ type Config struct {
 func LoadConfigFromEnv() (*Config, error) {
 	return &Config{
 		TeamsGRPCTarget:          envOrDefault("TEAMS_GRPC_TARGET", defaultTeamsGRPCTarget),
+		ChatGRPCTarget:           envOrDefault("CHAT_GRPC_TARGET", defaultChatGRPCTarget),
 		FilesGRPCTarget:          envOrDefault("FILES_GRPC_TARGET", defaultFilesGRPCTarget),
 		LLMGRPCTarget:            envOrDefault("LLM_GRPC_TARGET", defaultLLMGRPCTarget),
 		SecretsGRPCTarget:        envOrDefault("SECRETS_GRPC_TARGET", defaultSecretsGRPCTarget),

--- a/internal/platform/config_test.go
+++ b/internal/platform/config_test.go
@@ -4,6 +4,7 @@ import "testing"
 
 func TestLoadConfigFromEnv(t *testing.T) {
 	t.Setenv("TEAMS_GRPC_TARGET", "teams:50052")
+	t.Setenv("CHAT_GRPC_TARGET", "chat:50056")
 	t.Setenv("FILES_GRPC_TARGET", "files:50053")
 	t.Setenv("LLM_GRPC_TARGET", "llm:50054")
 	t.Setenv("SECRETS_GRPC_TARGET", "secrets:50055")
@@ -15,6 +16,10 @@ func TestLoadConfigFromEnv(t *testing.T) {
 
 	if got := cfg.TeamsGRPCTarget; got != "teams:50052" {
 		t.Fatalf("unexpected teams grpc target: %s", got)
+	}
+
+	if got := cfg.ChatGRPCTarget; got != "chat:50056" {
+		t.Fatalf("unexpected chat grpc target: %s", got)
 	}
 
 	if got := cfg.FilesGRPCTarget; got != "files:50053" {
@@ -45,6 +50,7 @@ func TestLoadConfigFromEnvMissingTeamsGRPC(t *testing.T) {
 
 func TestLoadConfigFromEnvAllDefaults(t *testing.T) {
 	t.Setenv("TEAMS_GRPC_TARGET", "")
+	t.Setenv("CHAT_GRPC_TARGET", "")
 	t.Setenv("FILES_GRPC_TARGET", "")
 	t.Setenv("LLM_GRPC_TARGET", "")
 	t.Setenv("SECRETS_GRPC_TARGET", "")
@@ -56,6 +62,9 @@ func TestLoadConfigFromEnvAllDefaults(t *testing.T) {
 
 	if cfg.TeamsGRPCTarget != defaultTeamsGRPCTarget {
 		t.Fatalf("unexpected teams grpc target: %s", cfg.TeamsGRPCTarget)
+	}
+	if cfg.ChatGRPCTarget != defaultChatGRPCTarget {
+		t.Fatalf("unexpected chat grpc target: %s", cfg.ChatGRPCTarget)
 	}
 	if cfg.FilesGRPCTarget != defaultFilesGRPCTarget {
 		t.Fatalf("unexpected files grpc target: %s", cfg.FilesGRPCTarget)

--- a/scripts/generate-openapi.sh
+++ b/scripts/generate-openapi.sh
@@ -10,12 +10,32 @@ ROOT_DIR="$(cd "${SCRIPT_DIR}/.." && pwd)"
 bash "${SCRIPT_DIR}/pull-spec.sh"
 
 # -- Step 2: Place specs for //go:embed -------------------------------
+mkdir -p "${ROOT_DIR}/internal/apischema/chatv1"
 mkdir -p "${ROOT_DIR}/internal/apischema/teamv1"
 mkdir -p "${ROOT_DIR}/internal/apischema/llmv1"
+cp "${ROOT_DIR}/.openapi/chat-v1.yaml" "${ROOT_DIR}/internal/apischema/chatv1/chat-v1.yaml"
 cp "${ROOT_DIR}/.openapi/team-v1.yaml" "${ROOT_DIR}/internal/apischema/teamv1/team-v1.yaml"
 cp "${ROOT_DIR}/.openapi/llm-v1.yaml"  "${ROOT_DIR}/internal/apischema/llmv1/llm-v1.yaml"
 
 # -- Step 3: Generate spec.go loaders ---------------------------------
+cat > "${ROOT_DIR}/internal/apischema/chatv1/spec.go" << 'GOEOF'
+package chatv1
+
+import (
+	_ "embed"
+
+	"github.com/getkin/kin-openapi/openapi3"
+)
+
+//go:embed chat-v1.yaml
+var Spec []byte
+
+func LoadSpec() (*openapi3.T, error) {
+	loader := openapi3.NewLoader()
+	return loader.LoadFromData(Spec)
+}
+GOEOF
+
 cat > "${ROOT_DIR}/internal/apischema/teamv1/spec.go" << 'GOEOF'
 package teamv1
 
@@ -53,8 +73,15 @@ func LoadSpec() (*openapi3.T, error) {
 GOEOF
 
 # -- Step 4: Run oapi-codegen -----------------------------------------
+mkdir -p "${ROOT_DIR}/internal/chatgen"
 mkdir -p "${ROOT_DIR}/internal/gen"
 mkdir -p "${ROOT_DIR}/internal/llmgen"
+
+oapi-codegen \
+  -package chatgen \
+  -generate chi-server,strict-server,models \
+  -o "${ROOT_DIR}/internal/chatgen/server.gen.go" \
+  "${ROOT_DIR}/.openapi/chat-v1.yaml"
 
 oapi-codegen \
   -package gen \
@@ -69,6 +96,7 @@ oapi-codegen \
   "${ROOT_DIR}/.openapi/llm-v1.yaml"
 
 # -- Step 5: Format generated code ------------------------------------
+gofmt -w "${ROOT_DIR}/internal/chatgen/server.gen.go"
 gofmt -w "${ROOT_DIR}/internal/gen/server.gen.go"
 gofmt -w "${ROOT_DIR}/internal/llmgen/server.gen.go"
 

--- a/scripts/pull-spec.sh
+++ b/scripts/pull-spec.sh
@@ -23,4 +23,5 @@ pull_spec() {
 }
 
 pull_spec "${TEAM_OPENAPI_IMAGE:-agynio/openapi/team:1}" "team-v1.yaml"
+pull_spec "${CHAT_OPENAPI_IMAGE:-agynio/openapi/chat:1}" "chat-v1.yaml"
 pull_spec "${LLM_OPENAPI_IMAGE:-agynio/openapi/llm:1}" "llm-v1.yaml"


### PR DESCRIPTION
## Summary
- expose Chat API routes with strict oapi-codegen server, gRPC client wiring, and conversion helpers
- add chat handler tests plus config/env/helm/devspace updates
- extend OpenAPI/proto generation scripts, Docker build, and CI redoc build for chat

## Testing
- nix shell nixpkgs#go nixpkgs#gcc -c go vet ./...
- nix shell nixpkgs#go nixpkgs#gcc -c go test ./...

Refs #73