### PR TITLE
feat(grpcclient): propagate identity metadata

### DIFF
--- a/internal/grpcclient/client.go
+++ b/internal/grpcclient/client.go
@@ -22,7 +22,12 @@ func New[T any](target string, factory func(grpc.ClientConnInterface) T) (*Clien
 		return nil, fmt.Errorf("client factory is required")
 	}
 
-	conn, err := grpc.NewClient(target, grpc.WithTransportCredentials(insecure.NewCredentials()))
+	conn, err := grpc.NewClient(
+		target,
+		grpc.WithTransportCredentials(insecure.NewCredentials()),
+		grpc.WithChainUnaryInterceptor(identityUnaryClientInterceptor()),
+		grpc.WithChainStreamInterceptor(identityStreamClientInterceptor()),
+	)
 	if err != nil {
 		return nil, err
 	}

--- a/internal/grpcclient/interceptors.go
+++ b/internal/grpcclient/interceptors.go
@@ -1,0 +1,43 @@
+package grpcclient
+
+import (
+	"context"
+
+	"github.com/agynio/gateway/internal/identity"
+	"google.golang.org/grpc"
+	"google.golang.org/grpc/metadata"
+)
+
+const (
+	identityIDMetadataKey   = "x-identity-id"
+	identityTypeMetadataKey = "x-identity-type"
+)
+
+func identityUnaryClientInterceptor() grpc.UnaryClientInterceptor {
+	return func(ctx context.Context, method string, req, reply any, cc *grpc.ClientConn, invoker grpc.UnaryInvoker, opts ...grpc.CallOption) error {
+		ctx = appendIdentityMetadata(ctx)
+		return invoker(ctx, method, req, reply, cc, opts...)
+	}
+}
+
+func identityStreamClientInterceptor() grpc.StreamClientInterceptor {
+	return func(ctx context.Context, desc *grpc.StreamDesc, cc *grpc.ClientConn, method string, streamer grpc.Streamer, opts ...grpc.CallOption) (grpc.ClientStream, error) {
+		ctx = appendIdentityMetadata(ctx)
+		return streamer(ctx, desc, cc, method, opts...)
+	}
+}
+
+func appendIdentityMetadata(ctx context.Context) context.Context {
+	resolved, ok := identity.IdentityFromContext(ctx)
+	if !ok {
+		return ctx
+	}
+
+	return metadata.AppendToOutgoingContext(
+		ctx,
+		identityIDMetadataKey,
+		resolved.IdentityID,
+		identityTypeMetadataKey,
+		string(resolved.IdentityType),
+	)
+}

--- a/internal/grpcclient/interceptors_test.go
+++ b/internal/grpcclient/interceptors_test.go
@@ -1,0 +1,72 @@
+package grpcclient
+
+import (
+	"context"
+	"testing"
+
+	"github.com/agynio/gateway/internal/identity"
+	"google.golang.org/grpc/metadata"
+)
+
+func TestAppendIdentityMetadataWithIdentity(t *testing.T) {
+	ctx := identity.WithIdentity(context.Background(), identity.ResolvedIdentity{
+		IdentityID:   "identity-123",
+		IdentityType: identity.IdentityTypeUser,
+		TenantID:     "tenant-1",
+		AuthMethod:   identity.AuthMethodOIDC,
+	})
+
+	ctx = appendIdentityMetadata(ctx)
+	md, ok := metadata.FromOutgoingContext(ctx)
+	if !ok {
+		t.Fatalf("expected outgoing metadata")
+	}
+
+	identityIDs := md.Get(identityIDMetadataKey)
+	if len(identityIDs) != 1 || identityIDs[0] != "identity-123" {
+		t.Fatalf("expected identity id metadata, got %v", identityIDs)
+	}
+
+	identityTypes := md.Get(identityTypeMetadataKey)
+	if len(identityTypes) != 1 || identityTypes[0] != string(identity.IdentityTypeUser) {
+		t.Fatalf("expected identity type metadata, got %v", identityTypes)
+	}
+}
+
+func TestAppendIdentityMetadataWithoutIdentity(t *testing.T) {
+	ctx := appendIdentityMetadata(context.Background())
+	if md, ok := metadata.FromOutgoingContext(ctx); ok {
+		t.Fatalf("expected no outgoing metadata, got %v", md)
+	}
+}
+
+func TestAppendIdentityMetadataPreservesExisting(t *testing.T) {
+	ctx := metadata.NewOutgoingContext(context.Background(), metadata.Pairs("existing", "value"))
+	ctx = identity.WithIdentity(ctx, identity.ResolvedIdentity{
+		IdentityID:   "identity-456",
+		IdentityType: identity.IdentityTypeAgent,
+		TenantID:     "tenant-2",
+		AuthMethod:   identity.AuthMethodZiti,
+	})
+
+	ctx = appendIdentityMetadata(ctx)
+	md, ok := metadata.FromOutgoingContext(ctx)
+	if !ok {
+		t.Fatalf("expected outgoing metadata")
+	}
+
+	existing := md.Get("existing")
+	if len(existing) != 1 || existing[0] != "value" {
+		t.Fatalf("expected existing metadata to be preserved, got %v", existing)
+	}
+
+	identityIDs := md.Get(identityIDMetadataKey)
+	if len(identityIDs) != 1 || identityIDs[0] != "identity-456" {
+		t.Fatalf("expected identity id metadata, got %v", identityIDs)
+	}
+
+	identityTypes := md.Get(identityTypeMetadataKey)
+	if len(identityTypes) != 1 || identityTypes[0] != string(identity.IdentityTypeAgent) {
+		t.Fatalf("expected identity type metadata, got %v", identityTypes)
+	}
+}


### PR DESCRIPTION
## Summary
- add gRPC client interceptors to append identity metadata
- wire identity interceptors into gRPC client creation
- cover metadata propagation with unit tests

## Testing
- nix shell nixpkgs#go nixpkgs#gcc -c go vet ./...
- nix shell nixpkgs#go nixpkgs#gcc -c go test ./...

Refs #82