### PR TITLE
feat: add API token auth flow

### DIFF
--- a/cmd/gateway/main.go
+++ b/cmd/gateway/main.go
@@ -28,6 +28,7 @@ import (
 	threadsv1 "github.com/agynio/gateway/gen/agynio/api/threads/v1"
 	tokencountingv1 "github.com/agynio/gateway/gen/agynio/api/token_counting/v1"
 	usersv1 "github.com/agynio/gateway/gen/agynio/api/users/v1"
+	"github.com/agynio/gateway/internal/apitokenresolver"
 	"github.com/agynio/gateway/internal/gateway"
 	"github.com/agynio/gateway/internal/grpcclient"
 	"github.com/agynio/gateway/internal/oidcauth"
@@ -73,6 +74,8 @@ func main() {
 		}
 	}()
 
+	usersClient := mustClient(config.UsersGRPCTarget, "users", usersv1.NewUsersServiceClient, &cleanup)
+
 	var oidcResolver gateway.BearerTokenResolver
 	oidcConfigured := config.OIDCIssuerURL != "" || config.OIDCClientID != ""
 	if oidcConfigured {
@@ -83,7 +86,6 @@ func main() {
 		if err != nil {
 			log.Fatalf("failed to create OIDC verifier: %v", err)
 		}
-		usersClient := mustClient(config.UsersGRPCTarget, "users", usersv1.NewUsersServiceClient, &cleanup)
 		userinfoHTTPClient := &http.Client{Timeout: 10 * time.Second}
 		resolver, err := oidcresolver.NewResolver(verifier, usersClient, userinfoHTTPClient)
 		if err != nil {
@@ -91,6 +93,8 @@ func main() {
 		}
 		oidcResolver = resolver
 	}
+
+	apiTokenResolver := apitokenresolver.NewResolver(usersClient)
 
 	agentsClient := mustClient(config.AgentsGRPCTarget, "agents", agentsv1.NewAgentsServiceClient, &cleanup)
 	threadsClient := mustClient(config.ThreadsGRPCTarget, "threads", threadsv1.NewThreadsServiceClient, &cleanup)
@@ -114,21 +118,22 @@ func main() {
 		secretsClient,
 	)
 	threadsGateway := gateway.NewThreadsGateway(gatewayHandler)
+	usersGateway := gateway.NewUsersGateway(usersClient)
 
 	interceptors := []connect.Interceptor{
 		gateway.NewRecoveryInterceptor(),
 		gateway.NewLoggingInterceptor(),
 	}
-	if zitiResolver != nil || oidcResolver != nil {
-		interceptors = append([]connect.Interceptor{gateway.NewAuthInterceptor(zitiResolver, oidcResolver)}, interceptors...)
+	if zitiResolver != nil || oidcResolver != nil || apiTokenResolver != nil {
+		interceptors = append([]connect.Interceptor{gateway.NewAuthInterceptor(zitiResolver, oidcResolver, apiTokenResolver)}, interceptors...)
 	}
 	handlerOptions := connect.WithInterceptors(interceptors...)
 
 	mux := http.NewServeMux()
 
 	var meHandler http.Handler = http.HandlerFunc(gateway.MeHandler)
-	if zitiResolver != nil || oidcResolver != nil {
-		meHandler = gateway.NewAuthMiddleware(zitiResolver, oidcResolver)(meHandler)
+	if zitiResolver != nil || oidcResolver != nil || apiTokenResolver != nil {
+		meHandler = gateway.NewAuthMiddleware(zitiResolver, oidcResolver, apiTokenResolver)(meHandler)
 	}
 	mux.Handle("/me", meHandler)
 
@@ -145,6 +150,7 @@ func main() {
 	registerConnect(gatewayv1connect.NewTokenCountingGatewayHandler(gatewayHandler, handlerOptions))
 	registerConnect(gatewayv1connect.NewLLMGatewayHandler(gatewayHandler, handlerOptions))
 	registerConnect(gatewayv1connect.NewSecretsGatewayHandler(gatewayHandler, handlerOptions))
+	registerConnect(gatewayv1connect.NewUsersGatewayHandler(usersGateway, handlerOptions))
 
 	corsMiddleware := cors.New(cors.Options{
 		AllowedOrigins: []string{"*"},

--- a/internal/apitokenresolver/resolver.go
+++ b/internal/apitokenresolver/resolver.go
@@ -1,0 +1,52 @@
+package apitokenresolver
+
+import (
+	"context"
+	"crypto/sha256"
+	"encoding/hex"
+	"strings"
+
+	usersv1 "github.com/agynio/gateway/gen/agynio/api/users/v1"
+	"github.com/agynio/gateway/internal/identity"
+	"google.golang.org/grpc/codes"
+	"google.golang.org/grpc/status"
+)
+
+const apiTokenPrefix = "agyn_"
+
+type Resolver struct {
+	usersClient usersv1.UsersServiceClient
+}
+
+func NewResolver(usersClient usersv1.UsersServiceClient) *Resolver {
+	return &Resolver{usersClient: usersClient}
+}
+
+func HasPrefix(token string) bool {
+	return strings.HasPrefix(token, apiTokenPrefix)
+}
+
+func (r *Resolver) ResolveFromToken(ctx context.Context, accessToken string) (identity.ResolvedIdentity, error) {
+	hash := sha256.Sum256([]byte(accessToken))
+	tokenHash := hex.EncodeToString(hash[:])
+
+	resp, err := r.usersClient.ResolveAPIToken(ctx, &usersv1.ResolveAPITokenRequest{TokenHash: tokenHash})
+	if err != nil {
+		switch status.Code(err) {
+		case codes.NotFound, codes.Unauthenticated:
+			return identity.ResolvedIdentity{}, status.Error(codes.Unauthenticated, "invalid api token")
+		default:
+			return identity.ResolvedIdentity{}, err
+		}
+	}
+	if resp == nil {
+		return identity.ResolvedIdentity{}, status.Error(codes.Internal, "api token response missing")
+	}
+
+	identityID := strings.TrimSpace(resp.GetIdentityId())
+	if identityID == "" {
+		return identity.ResolvedIdentity{}, status.Error(codes.Internal, "identity id missing")
+	}
+
+	return identity.ResolvedIdentity{IdentityID: identityID, IdentityType: identity.IdentityTypeUser}, nil
+}

--- a/internal/gateway/interceptors.go
+++ b/internal/gateway/interceptors.go
@@ -9,6 +9,7 @@ import (
 	"time"
 
 	"connectrpc.com/connect"
+	"github.com/agynio/gateway/internal/apitokenresolver"
 	"github.com/agynio/gateway/internal/httpauth"
 	"github.com/agynio/gateway/internal/identity"
 	"github.com/agynio/gateway/internal/ziticonn"
@@ -24,15 +25,15 @@ type BearerTokenResolver interface {
 	ResolveFromToken(ctx context.Context, accessToken string) (identity.ResolvedIdentity, error)
 }
 
-func NewAuthInterceptor(zitiResolver IdentityResolver, oidcResolver BearerTokenResolver) connect.Interceptor {
-	if zitiResolver == nil && oidcResolver == nil {
+func NewAuthInterceptor(zitiResolver IdentityResolver, oidcResolver BearerTokenResolver, apiTokenResolver BearerTokenResolver) connect.Interceptor {
+	if zitiResolver == nil && oidcResolver == nil && apiTokenResolver == nil {
 		panic("at least one identity resolver is required")
 	}
-	return authInterceptor{zitiResolver: zitiResolver, oidcResolver: oidcResolver}
+	return authInterceptor{zitiResolver: zitiResolver, oidcResolver: oidcResolver, apiTokenResolver: apiTokenResolver}
 }
 
-func NewAuthMiddleware(zitiResolver IdentityResolver, oidcResolver BearerTokenResolver) func(http.Handler) http.Handler {
-	if zitiResolver == nil && oidcResolver == nil {
+func NewAuthMiddleware(zitiResolver IdentityResolver, oidcResolver BearerTokenResolver, apiTokenResolver BearerTokenResolver) func(http.Handler) http.Handler {
+	if zitiResolver == nil && oidcResolver == nil && apiTokenResolver == nil {
 		panic("at least one identity resolver is required")
 	}
 
@@ -44,7 +45,7 @@ func NewAuthMiddleware(zitiResolver IdentityResolver, oidcResolver BearerTokenRe
 			}
 
 			ctx := withBearerToken(r.Context(), r.Header.Get("Authorization"))
-			ctx, err := resolveIdentity(ctx, zitiResolver, oidcResolver)
+			ctx, err := resolveIdentity(ctx, zitiResolver, oidcResolver, apiTokenResolver)
 			if err != nil {
 				writeProblem(w, httpStatusFromError(err), err.Error())
 				return
@@ -56,14 +57,15 @@ func NewAuthMiddleware(zitiResolver IdentityResolver, oidcResolver BearerTokenRe
 }
 
 type authInterceptor struct {
-	zitiResolver IdentityResolver
-	oidcResolver BearerTokenResolver
+	zitiResolver     IdentityResolver
+	oidcResolver     BearerTokenResolver
+	apiTokenResolver BearerTokenResolver
 }
 
 func (a authInterceptor) WrapUnary(next connect.UnaryFunc) connect.UnaryFunc {
 	return func(ctx context.Context, req connect.AnyRequest) (connect.AnyResponse, error) {
 		ctx = withBearerToken(ctx, req.Header().Get("Authorization"))
-		ctx, err := resolveIdentity(ctx, a.zitiResolver, a.oidcResolver)
+		ctx, err := resolveIdentity(ctx, a.zitiResolver, a.oidcResolver, a.apiTokenResolver)
 		if err != nil {
 			return nil, toConnectError(err)
 		}
@@ -78,7 +80,7 @@ func (a authInterceptor) WrapStreamingClient(next connect.StreamingClientFunc) c
 func (a authInterceptor) WrapStreamingHandler(next connect.StreamingHandlerFunc) connect.StreamingHandlerFunc {
 	return func(ctx context.Context, conn connect.StreamingHandlerConn) error {
 		ctx = withBearerToken(ctx, conn.RequestHeader().Get("Authorization"))
-		ctx, err := resolveIdentity(ctx, a.zitiResolver, a.oidcResolver)
+		ctx, err := resolveIdentity(ctx, a.zitiResolver, a.oidcResolver, a.apiTokenResolver)
 		if err != nil {
 			return toConnectError(err)
 		}
@@ -158,7 +160,7 @@ func (loggingInterceptor) WrapStreamingHandler(next connect.StreamingHandlerFunc
 	}
 }
 
-func resolveIdentity(ctx context.Context, zitiResolver IdentityResolver, oidcResolver BearerTokenResolver) (context.Context, error) {
+func resolveIdentity(ctx context.Context, zitiResolver IdentityResolver, oidcResolver BearerTokenResolver, apiTokenResolver BearerTokenResolver) (context.Context, error) {
 	sourceIdentity, ok := ziticonn.SourceIdentityFromContext(ctx)
 	if ok {
 		if zitiResolver == nil {
@@ -173,6 +175,16 @@ func resolveIdentity(ctx context.Context, zitiResolver IdentityResolver, oidcRes
 
 	accessToken, ok := httpauth.BearerTokenFromContext(ctx)
 	if ok {
+		if apitokenresolver.HasPrefix(accessToken) {
+			if apiTokenResolver == nil {
+				return ctx, status.Error(codes.Unauthenticated, "api token resolver is not configured")
+			}
+			resolvedIdentity, err := apiTokenResolver.ResolveFromToken(ctx, accessToken)
+			if err != nil {
+				return ctx, err
+			}
+			return identity.WithIdentity(ctx, resolvedIdentity), nil
+		}
 		if oidcResolver == nil {
 			return ctx, status.Error(codes.Unauthenticated, "oidc resolver is not configured")
 		}

--- a/internal/gateway/interceptors_test.go
+++ b/internal/gateway/interceptors_test.go
@@ -47,6 +47,22 @@ func (f *fakeOIDCResolver) ResolveFromToken(ctx context.Context, accessToken str
 	return f.resolved, nil
 }
 
+type fakeAPITokenResolver struct {
+	resolved  identity.ResolvedIdentity
+	err       error
+	calls     int
+	lastToken string
+}
+
+func (f *fakeAPITokenResolver) ResolveFromToken(ctx context.Context, accessToken string) (identity.ResolvedIdentity, error) {
+	f.calls++
+	f.lastToken = accessToken
+	if f.err != nil {
+		return identity.ResolvedIdentity{}, f.err
+	}
+	return f.resolved, nil
+}
+
 func TestAuthInterceptorWrapUnarySuccess(t *testing.T) {
 	resolver := &fakeZitiResolver{
 		resolved: identity.ResolvedIdentity{
@@ -167,7 +183,7 @@ func TestRecoveryInterceptorWrapUnary(t *testing.T) {
 
 func TestNewAuthMiddlewareOptionsPassthrough(t *testing.T) {
 	resolver := &fakeZitiResolver{}
-	middleware := NewAuthMiddleware(resolver, nil)
+	middleware := NewAuthMiddleware(resolver, nil, nil)
 
 	called := false
 	handler := http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
@@ -192,7 +208,7 @@ func TestNewAuthMiddlewareOptionsPassthrough(t *testing.T) {
 
 func TestNewAuthMiddlewareMissingIdentity(t *testing.T) {
 	resolver := &fakeZitiResolver{}
-	middleware := NewAuthMiddleware(resolver, nil)
+	middleware := NewAuthMiddleware(resolver, nil, nil)
 
 	handler := http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		if _, ok := identity.IdentityFromContext(r.Context()); ok {
@@ -221,7 +237,7 @@ func TestNewAuthMiddlewareSuccess(t *testing.T) {
 			IdentityType: identity.IdentityTypeUser,
 		},
 	}
-	middleware := NewAuthMiddleware(resolver, nil)
+	middleware := NewAuthMiddleware(resolver, nil, nil)
 
 	handler := http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		if _, ok := identity.IdentityFromContext(r.Context()); !ok {
@@ -251,7 +267,7 @@ func TestNewAuthMiddlewareBearer(t *testing.T) {
 			IdentityType: identity.IdentityTypeUser,
 		},
 	}
-	middleware := NewAuthMiddleware(nil, resolver)
+	middleware := NewAuthMiddleware(nil, resolver, nil)
 
 	handler := http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		if _, ok := identity.IdentityFromContext(r.Context()); !ok {
@@ -277,7 +293,7 @@ func TestNewAuthMiddlewareBearer(t *testing.T) {
 func TestResolveIdentityWithoutSource(t *testing.T) {
 	zitiResolver := &fakeZitiResolver{}
 	oidcResolver := &fakeOIDCResolver{}
-	ctx, err := resolveIdentity(context.Background(), zitiResolver, oidcResolver)
+	ctx, err := resolveIdentity(context.Background(), zitiResolver, oidcResolver, nil)
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}
@@ -300,7 +316,7 @@ func TestResolveIdentityWithSource(t *testing.T) {
 		},
 	}
 	ctx := ziticonn.WithSourceIdentity(context.Background(), "source-identity")
-	ctx, err := resolveIdentity(ctx, resolver, nil)
+	ctx, err := resolveIdentity(ctx, resolver, nil, nil)
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}
@@ -324,7 +340,7 @@ func TestResolveIdentityWithBearer(t *testing.T) {
 		},
 	}
 	ctx := httpauth.WithBearerToken(context.Background(), "token-bearer")
-	ctx, err := resolveIdentity(ctx, nil, resolver)
+	ctx, err := resolveIdentity(ctx, nil, resolver, nil)
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}
@@ -340,6 +356,106 @@ func TestResolveIdentityWithBearer(t *testing.T) {
 	}
 	if resolver.lastToken != "token-bearer" {
 		t.Fatalf("expected token to be propagated, got %q", resolver.lastToken)
+	}
+}
+
+func TestResolveIdentityWithAPIToken(t *testing.T) {
+	apiResolver := &fakeAPITokenResolver{
+		resolved: identity.ResolvedIdentity{
+			IdentityID:   "identity-api",
+			IdentityType: identity.IdentityTypeUser,
+		},
+	}
+	oidcResolver := &fakeOIDCResolver{
+		resolved: identity.ResolvedIdentity{
+			IdentityID:   "identity-oidc",
+			IdentityType: identity.IdentityTypeUser,
+		},
+	}
+	ctx := httpauth.WithBearerToken(context.Background(), "agyn_token")
+	ctx, err := resolveIdentity(ctx, nil, oidcResolver, apiResolver)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	resolved, ok := identity.IdentityFromContext(ctx)
+	if !ok {
+		t.Fatalf("expected identity in context")
+	}
+	if resolved.IdentityID != apiResolver.resolved.IdentityID {
+		t.Fatalf("expected identity %q, got %q", apiResolver.resolved.IdentityID, resolved.IdentityID)
+	}
+	if apiResolver.calls != 1 {
+		t.Fatalf("expected api token resolver to be called once, got %d", apiResolver.calls)
+	}
+	if apiResolver.lastToken != "agyn_token" {
+		t.Fatalf("expected token to be propagated, got %q", apiResolver.lastToken)
+	}
+	if oidcResolver.calls != 0 {
+		t.Fatalf("expected oidc resolver not to be called, got %d", oidcResolver.calls)
+	}
+}
+
+func TestResolveIdentityOIDCTokenNotPrefixed(t *testing.T) {
+	apiResolver := &fakeAPITokenResolver{
+		resolved: identity.ResolvedIdentity{
+			IdentityID:   "identity-api",
+			IdentityType: identity.IdentityTypeUser,
+		},
+	}
+	oidcResolver := &fakeOIDCResolver{
+		resolved: identity.ResolvedIdentity{
+			IdentityID:   "identity-oidc",
+			IdentityType: identity.IdentityTypeUser,
+		},
+	}
+	ctx := httpauth.WithBearerToken(context.Background(), "token-oidc")
+	ctx, err := resolveIdentity(ctx, nil, oidcResolver, apiResolver)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	resolved, ok := identity.IdentityFromContext(ctx)
+	if !ok {
+		t.Fatalf("expected identity in context")
+	}
+	if resolved.IdentityID != oidcResolver.resolved.IdentityID {
+		t.Fatalf("expected identity %q, got %q", oidcResolver.resolved.IdentityID, resolved.IdentityID)
+	}
+	if oidcResolver.calls != 1 {
+		t.Fatalf("expected oidc resolver to be called once, got %d", oidcResolver.calls)
+	}
+	if oidcResolver.lastToken != "token-oidc" {
+		t.Fatalf("expected token to be propagated, got %q", oidcResolver.lastToken)
+	}
+	if apiResolver.calls != 0 {
+		t.Fatalf("expected api token resolver not to be called, got %d", apiResolver.calls)
+	}
+}
+
+func TestResolveIdentityAPITokenResolverNil(t *testing.T) {
+	oidcResolver := &fakeOIDCResolver{}
+	ctx := httpauth.WithBearerToken(context.Background(), "agyn_missing")
+	_, err := resolveIdentity(ctx, nil, oidcResolver, nil)
+	if status.Code(err) != codes.Unauthenticated {
+		t.Fatalf("expected unauthenticated error, got %v", err)
+	}
+	if oidcResolver.calls != 0 {
+		t.Fatalf("expected oidc resolver not to be called, got %d", oidcResolver.calls)
+	}
+}
+
+func TestResolveIdentityAPITokenError(t *testing.T) {
+	apiResolver := &fakeAPITokenResolver{err: status.Error(codes.Internal, "boom")}
+	oidcResolver := &fakeOIDCResolver{}
+	ctx := httpauth.WithBearerToken(context.Background(), "agyn_error")
+	_, err := resolveIdentity(ctx, nil, oidcResolver, apiResolver)
+	if status.Code(err) != codes.Internal {
+		t.Fatalf("expected internal error, got %v", err)
+	}
+	if apiResolver.calls != 1 {
+		t.Fatalf("expected api token resolver to be called once, got %d", apiResolver.calls)
+	}
+	if oidcResolver.calls != 0 {
+		t.Fatalf("expected oidc resolver not to be called, got %d", oidcResolver.calls)
 	}
 }
 
@@ -359,7 +475,7 @@ func TestResolveIdentityPrefersZiti(t *testing.T) {
 
 	ctx := ziticonn.WithSourceIdentity(context.Background(), "source-identity")
 	ctx = httpauth.WithBearerToken(ctx, "token-preferred")
-	ctx, err := resolveIdentity(ctx, zitiResolver, oidcResolver)
+	ctx, err := resolveIdentity(ctx, zitiResolver, oidcResolver, nil)
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}

--- a/internal/gateway/users.go
+++ b/internal/gateway/users.go
@@ -1,0 +1,40 @@
+package gateway
+
+import (
+	"context"
+
+	"connectrpc.com/connect"
+	usersv1 "github.com/agynio/gateway/gen/agynio/api/users/v1"
+)
+
+type UsersGateway struct {
+	users usersv1.UsersServiceClient
+}
+
+func NewUsersGateway(users usersv1.UsersServiceClient) *UsersGateway {
+	return &UsersGateway{users: users}
+}
+
+func (g *UsersGateway) CreateAPIToken(ctx context.Context, req *connect.Request[usersv1.CreateAPITokenRequest]) (*connect.Response[usersv1.CreateAPITokenResponse], error) {
+	resp, err := g.users.CreateAPIToken(ctx, req.Msg)
+	if err != nil {
+		return nil, toConnectError(err)
+	}
+	return connect.NewResponse(resp), nil
+}
+
+func (g *UsersGateway) ListAPITokens(ctx context.Context, req *connect.Request[usersv1.ListAPITokensRequest]) (*connect.Response[usersv1.ListAPITokensResponse], error) {
+	resp, err := g.users.ListAPITokens(ctx, req.Msg)
+	if err != nil {
+		return nil, toConnectError(err)
+	}
+	return connect.NewResponse(resp), nil
+}
+
+func (g *UsersGateway) RevokeAPIToken(ctx context.Context, req *connect.Request[usersv1.RevokeAPITokenRequest]) (*connect.Response[usersv1.RevokeAPITokenResponse], error) {
+	resp, err := g.users.RevokeAPIToken(ctx, req.Msg)
+	if err != nil {
+		return nil, toConnectError(err)
+	}
+	return connect.NewResponse(resp), nil
+}

--- a/internal/oidcresolver/resolver_test.go
+++ b/internal/oidcresolver/resolver_test.go
@@ -222,6 +222,22 @@ func (f *fakeUsersClient) UpdateUser(ctx context.Context, in *usersv1.UpdateUser
 	return nil, status.Error(codes.Unimplemented, "not implemented")
 }
 
+func (f *fakeUsersClient) CreateAPIToken(ctx context.Context, in *usersv1.CreateAPITokenRequest, opts ...grpc.CallOption) (*usersv1.CreateAPITokenResponse, error) {
+	return nil, status.Error(codes.Unimplemented, "not implemented")
+}
+
+func (f *fakeUsersClient) ListAPITokens(ctx context.Context, in *usersv1.ListAPITokensRequest, opts ...grpc.CallOption) (*usersv1.ListAPITokensResponse, error) {
+	return nil, status.Error(codes.Unimplemented, "not implemented")
+}
+
+func (f *fakeUsersClient) RevokeAPIToken(ctx context.Context, in *usersv1.RevokeAPITokenRequest, opts ...grpc.CallOption) (*usersv1.RevokeAPITokenResponse, error) {
+	return nil, status.Error(codes.Unimplemented, "not implemented")
+}
+
+func (f *fakeUsersClient) ResolveAPIToken(ctx context.Context, in *usersv1.ResolveAPITokenRequest, opts ...grpc.CallOption) (*usersv1.ResolveAPITokenResponse, error) {
+	return nil, status.Error(codes.Unimplemented, "not implemented")
+}
+
 func buildUser(id string) *usersv1.User {
 	return &usersv1.User{Meta: &usersv1.EntityMeta{Id: id}}
 }


### PR DESCRIPTION
## Summary
- add API token resolver with hashed token lookup and unauthenticated mapping
- route auth by token prefix and wire UsersGateway handlers
- expand interceptor and OIDC resolver tests for new users RPCs

## Testing
- nix shell nixpkgs#go nixpkgs#gcc -c go vet ./...
- nix shell nixpkgs#go nixpkgs#gcc -c go test ./...

Closes #84