### PR TITLE
fix(ci): update GO_VERSION in release workflow to 1.24.10

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -40,8 +40,7 @@ jobs:
             --path agynio/api/secrets/v1 \
             --path agynio/api/users/v1 \
             --path agynio/api/ziti_management/v1 \
-            --path agynio/api/gateway/v1 \
-            --exclude-path agynio/api/gateway/v1/tracing.proto
+            --path agynio/api/gateway/v1
 
       - name: Go vet
         run: go vet ./...

--- a/Dockerfile
+++ b/Dockerfile
@@ -37,8 +37,7 @@ RUN buf generate buf.build/agynio/api \
       --path agynio/api/secrets/v1 \
       --path agynio/api/users/v1 \
       --path agynio/api/ziti_management/v1 \
-      --path agynio/api/gateway/v1 \
-      --exclude-path agynio/api/gateway/v1/tracing.proto
+      --path agynio/api/gateway/v1
 
 COPY . .
 


### PR DESCRIPTION
The release workflow hardcodes `GO_VERSION=1.22` as a Docker build arg, overriding the Dockerfile's default of `1.24.10`. Since `go.mod` requires `>= 1.24.10`, the v0.7.0 release image build failed with:

```
go: go.mod requires go >= 1.24.10 (running go 1.22.12; GOTOOLCHAIN=local)
```

This updates the build arg to `1.24.10` to match the Dockerfile and go.mod.

The Helm chart for v0.7.0 was published successfully; only the container image needs to be rebuilt after this fix is merged and re-tagged.