### PR TITLE
Expose Ziti config in Helm chart

### DIFF
--- a/charts/gateway/templates/_helpers.tpl
+++ b/charts/gateway/templates/_helpers.tpl
@@ -41,6 +41,17 @@
 {{- $env = append $env (dict "name" "OIDC_CLIENT_ID" "value" $oidcClientId) -}}
 {{- end -}}
 
+{{- $zitiEnabled := .Values.gateway.zitiEnabled | default false -}}
+{{- $env = append $env (dict "name" "ZITI_ENABLED" "value" (printf "%t" $zitiEnabled)) -}}
+
+{{- $zitiManagementGrpcTarget := trimAll " \n\t" (default "" .Values.gateway.zitiManagementGrpcTarget) -}}
+{{- $env = append $env (dict "name" "ZITI_MANAGEMENT_GRPC_TARGET" "value" $zitiManagementGrpcTarget) -}}
+
+{{- $zitiLeaseRenewalInterval := trimAll " \n\t" (default "" .Values.gateway.zitiLeaseRenewalInterval) -}}
+{{- if $zitiLeaseRenewalInterval -}}
+{{- $env = append $env (dict "name" "ZITI_LEASE_RENEWAL_INTERVAL" "value" $zitiLeaseRenewalInterval) -}}
+{{- end -}}
+
 {{- $userEnv := .Values.env | default (list) -}}
 {{- $_ := set .Values "env" (concat $env $userEnv) -}}
 {{- end -}}

--- a/charts/gateway/values.yaml
+++ b/charts/gateway/values.yaml
@@ -163,3 +163,6 @@ gateway:
   usersGrpcTarget: "users:50051"
   oidcIssuerUrl: ""
   oidcClientId: ""
+  zitiEnabled: false
+  zitiManagementGrpcTarget: "ziti-management:50051"
+  zitiLeaseRenewalInterval: ""


### PR DESCRIPTION
## Summary
- add Ziti values to the Helm chart defaults
- map Ziti env vars in the gateway Helm helper

## Testing
- nix shell nixpkgs#buf -c buf generate buf.build/agynio/api --path agynio/api/agents/v1 --path agynio/api/threads/v1 --path agynio/api/chat/v1 --path agynio/api/notifications/v1 --path agynio/api/files/v1 --path agynio/api/agent_state/v1 --path agynio/api/token_counting/v1 --path agynio/api/llm/v1 --path agynio/api/secrets/v1 --path agynio/api/users/v1 --path agynio/api/ziti_management/v1 --path agynio/api/gateway/v1
- nix shell nixpkgs#go nixpkgs#gcc -c go vet ./...
- nix shell nixpkgs#go nixpkgs#gcc -c go test ./...
- nix shell nixpkgs#kubernetes-helm -c helm dependency build charts/gateway
- nix shell nixpkgs#kubernetes-helm -c helm lint charts/gateway --set gateway.platformBaseUrl=https://platform.example.com

## Issue
- #91