### PR TITLE
fix(oidc): remove access token aud check

### DIFF
--- a/internal/oidcauth/verifier.go
+++ b/internal/oidcauth/verifier.go
@@ -80,9 +80,6 @@ func (v *Verifier) Verify(ctx context.Context, accessToken string) (Claims, erro
 	if err := oidc.CheckIssuer(&parsed, v.issuer); err != nil {
 		return Claims{}, err
 	}
-	if err := oidc.CheckAudience(&parsed, v.clientID); err != nil {
-		return Claims{}, err
-	}
 	if err := oidc.CheckSignature(ctx, decrypted, payload, &parsed, v.supportedSignAlgs, v.keySet); err != nil {
 		return Claims{}, err
 	}

--- a/internal/oidcauth/verifier_test.go
+++ b/internal/oidcauth/verifier_test.go
@@ -3,17 +3,26 @@ package oidcauth
 import (
 	"context"
 	"testing"
+	"time"
 
 	"github.com/agynio/gateway/internal/oidctestutil"
+	"github.com/zitadel/oidc/v3/pkg/oidc"
 )
 
-func TestVerifierVerifySubject(t *testing.T) {
-	provider := oidctestutil.NewProvider(t)
+func newVerifier(t *testing.T, provider *oidctestutil.Provider) *Verifier {
+	t.Helper()
 
 	verifier, err := NewVerifier(context.Background(), provider.Issuer, provider.ClientID)
 	if err != nil {
 		t.Fatalf("failed to create verifier: %v", err)
 	}
+
+	return verifier
+}
+
+func TestVerifierVerifySubject(t *testing.T) {
+	provider := oidctestutil.NewProvider(t)
+	verifier := newVerifier(t, provider)
 
 	claims, err := verifier.Verify(context.Background(), provider.Token)
 	if err != nil {
@@ -24,5 +33,49 @@ func TestVerifierVerifySubject(t *testing.T) {
 	}
 	if verifier.UserinfoEndpoint() != provider.UserinfoEndpoint {
 		t.Fatalf("expected userinfo endpoint %q, got %q", provider.UserinfoEndpoint, verifier.UserinfoEndpoint())
+	}
+}
+
+func TestVerifierVerifyAcceptsResourceServerAudience(t *testing.T) {
+	provider := oidctestutil.NewProvider(t)
+	verifier := newVerifier(t, provider)
+
+	claims := oidc.NewAccessTokenClaims(
+		provider.Issuer,
+		provider.Subject,
+		[]string{"https://api.example.com"},
+		time.Now().Add(time.Hour),
+		"jwtid",
+		provider.ClientID,
+		time.Second,
+	)
+	token := provider.SignAccessToken(t, claims)
+
+	if _, err := verifier.Verify(context.Background(), token); err != nil {
+		t.Fatalf("failed to verify token: %v", err)
+	}
+}
+
+func TestVerifierVerifyAcceptsEmptyAudience(t *testing.T) {
+	provider := oidctestutil.NewProvider(t)
+	verifier := newVerifier(t, provider)
+
+	now := time.Now().UTC().Add(-time.Second)
+	claims := &oidc.AccessTokenClaims{
+		TokenClaims: oidc.TokenClaims{
+			Issuer:     provider.Issuer,
+			Subject:    provider.Subject,
+			Audience:   oidc.Audience{},
+			Expiration: oidc.FromTime(now.Add(time.Hour)),
+			IssuedAt:   oidc.FromTime(now),
+			NotBefore:  oidc.FromTime(now),
+			ClientID:   provider.ClientID,
+			JWTID:      "jwtid",
+		},
+	}
+	token := provider.SignAccessToken(t, claims)
+
+	if _, err := verifier.Verify(context.Background(), token); err != nil {
+		t.Fatalf("failed to verify token: %v", err)
 	}
 }

--- a/internal/oidctestutil/provider.go
+++ b/internal/oidctestutil/provider.go
@@ -24,6 +24,7 @@ type Provider struct {
 	Server           *httptest.Server
 	UserinfoCalls    int
 	LastAuthHeader   string
+	signer           jose.Signer
 }
 
 type Option func(*providerConfig)
@@ -87,6 +88,7 @@ func NewProvider(t *testing.T, opts ...Option) *Provider {
 		ClientID: cfg.clientID,
 		Subject:  cfg.subject,
 		UserInfo: cfg.userInfo,
+		signer:   signer,
 	}
 
 	var issuer string
@@ -127,7 +129,7 @@ func NewProvider(t *testing.T, opts ...Option) *Provider {
 	claims := oidc.NewAccessTokenClaims(
 		issuer,
 		provider.Subject,
-		[]string{provider.ClientID},
+		[]string{issuer},
 		time.Now().Add(time.Hour),
 		"jwtid",
 		provider.ClientID,
@@ -136,6 +138,12 @@ func NewProvider(t *testing.T, opts ...Option) *Provider {
 	provider.Token = SignToken(t, signer, claims)
 
 	return provider
+}
+
+func (p *Provider) SignAccessToken(t *testing.T, claims *oidc.AccessTokenClaims) string {
+	t.Helper()
+
+	return SignToken(t, p.signer, claims)
 }
 
 func NewRSAKey(t *testing.T) *rsa.PrivateKey {


### PR DESCRIPTION
## Summary
- remove access-token audience enforcement in the verifier
- make test provider tokens use resource-server audiences by default
- add verifier tests for resource-server and empty audiences

## Testing
- `nix shell nixpkgs#go nixpkgs#gcc -c go vet ./...`
- `nix shell nixpkgs#go nixpkgs#gcc -c go test ./...`

Fixes #95