### PR TITLE
feat: add EnrollApp proxy method

### DIFF
--- a/buf.lock
+++ b/buf.lock
@@ -2,8 +2,8 @@
 version: v2
 deps:
   - name: buf.build/agynio/api
-    commit: 07b4eb9abdf04686ba06ceeb2bdc4315
-    digest: b5:adbf109e7d5ce8ae9fab0891a3f9ab8492dfaa41f7ed9abf26bc444ac7496554be8380b37a34192b461cb9abbffb16e9d8907260fe10725c9a9e6547ce2c87af
+    commit: 3f9d7062db064c7ba683a392ef75e674
+    digest: b5:7dee517f5ecb3a9b2a24acc568c7b988035ce59ab4f9858f726657244afd1964cb4304c2b3a089491aa3030d801390c936c3028d5f5158b370ef7ea12cb00cb8
   - name: buf.build/opentelemetry/opentelemetry
     commit: 5f2c7d4f740541589805e0816dad4bb0
     digest: b5:935626c896cfe0f5efda467869c65df49843190c1d16ad24957d62ae840aef5f5da2474ec5c766e730b2727c6a24b39b5a2a073da70cf3f2611ce7d3934def86

--- a/internal/gateway/appproxy_test.go
+++ b/internal/gateway/appproxy_test.go
@@ -23,6 +23,10 @@ func (f *fakeAppsClient) RegisterApp(ctx context.Context, req *appsv1.RegisterAp
 	return nil, status.Error(codes.Unimplemented, "not implemented")
 }
 
+func (f *fakeAppsClient) EnrollApp(ctx context.Context, req *appsv1.EnrollAppRequest, opts ...grpc.CallOption) (*appsv1.EnrollAppResponse, error) {
+	return nil, status.Error(codes.Unimplemented, "not implemented")
+}
+
 func (f *fakeAppsClient) GetApp(ctx context.Context, req *appsv1.GetAppRequest, opts ...grpc.CallOption) (*appsv1.GetAppResponse, error) {
 	return nil, status.Error(codes.Unimplemented, "not implemented")
 }

--- a/internal/gateway/apps.go
+++ b/internal/gateway/apps.go
@@ -15,6 +15,14 @@ func (g *Gateway) RegisterApp(ctx context.Context, req *connect.Request[appsv1.R
 	return connect.NewResponse(resp), nil
 }
 
+func (g *Gateway) EnrollApp(ctx context.Context, req *connect.Request[appsv1.EnrollAppRequest]) (*connect.Response[appsv1.EnrollAppResponse], error) {
+	resp, err := g.apps.EnrollApp(ctx, req.Msg)
+	if err != nil {
+		return nil, toConnectError(err)
+	}
+	return connect.NewResponse(resp), nil
+}
+
 func (g *Gateway) GetApp(ctx context.Context, req *connect.Request[appsv1.GetAppRequest]) (*connect.Response[appsv1.GetAppResponse], error) {
 	resp, err := g.apps.GetApp(ctx, req.Msg)
 	if err != nil {


### PR DESCRIPTION
## Summary
- update buf.lock for latest api dependency
- add EnrollApp proxy method in apps gateway handler
- add EnrollApp stub to fake apps client tests

## Testing
- nix shell nixpkgs#go nixpkgs#gcc -c go vet ./...
- nix shell nixpkgs#go nixpkgs#gcc -c go test ./...

Closes #109