### PR TITLE
fix(build): generate users gateway stubs

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -50,8 +50,7 @@ jobs:
             --path agynio/api/users/v1 \
             --path agynio/api/organizations/v1 \
             --path agynio/api/ziti_management/v1 \
-            --path agynio/api/gateway/v1 \
-            --exclude-path agynio/api/gateway/v1/users.proto
+            --path agynio/api/gateway/v1
 
       - name: Go vet
         run: go vet ./...

--- a/Dockerfile
+++ b/Dockerfile
@@ -42,8 +42,7 @@ RUN buf generate buf.build/agynio/api \
       --path agynio/api/users/v1 \
       --path agynio/api/organizations/v1 \
       --path agynio/api/ziti_management/v1 \
-      --path agynio/api/gateway/v1 \
-      --exclude-path agynio/api/gateway/v1/users.proto
+      --path agynio/api/gateway/v1
 
 COPY . .
 

--- a/gen/agynio/api/gateway/v1/gatewayv1connect/users.connect.go
+++ b/gen/agynio/api/gateway/v1/gatewayv1connect/users.connect.go
@@ -34,9 +34,6 @@ const (
 // reflection-formatted method names, remove the leading slash and convert the remaining slash to a
 // period.
 const (
-	// UsersGatewayBatchGetUsersProcedure is the fully-qualified name of the UsersGateway's
-	// BatchGetUsers RPC.
-	UsersGatewayBatchGetUsersProcedure = "/agynio.api.gateway.v1.UsersGateway/BatchGetUsers"
 	// UsersGatewayCreateAPITokenProcedure is the fully-qualified name of the UsersGateway's
 	// CreateAPIToken RPC.
 	UsersGatewayCreateAPITokenProcedure = "/agynio.api.gateway.v1.UsersGateway/CreateAPIToken"
@@ -46,17 +43,18 @@ const (
 	// UsersGatewayRevokeAPITokenProcedure is the fully-qualified name of the UsersGateway's
 	// RevokeAPIToken RPC.
 	UsersGatewayRevokeAPITokenProcedure = "/agynio.api.gateway.v1.UsersGateway/RevokeAPIToken"
+	// UsersGatewayBatchGetUsersProcedure is the fully-qualified name of the UsersGateway's
+	// BatchGetUsers RPC.
+	UsersGatewayBatchGetUsersProcedure = "/agynio.api.gateway.v1.UsersGateway/BatchGetUsers"
 )
 
 // UsersGatewayClient is a client for the agynio.api.gateway.v1.UsersGateway service.
 type UsersGatewayClient interface {
-	// --- Users ---
-	BatchGetUsers(context.Context, *connect.Request[v1.BatchGetUsersRequest]) (*connect.Response[v1.BatchGetUsersResponse], error)
-
 	// --- API Tokens ---
 	CreateAPIToken(context.Context, *connect.Request[v1.CreateAPITokenRequest]) (*connect.Response[v1.CreateAPITokenResponse], error)
 	ListAPITokens(context.Context, *connect.Request[v1.ListAPITokensRequest]) (*connect.Response[v1.ListAPITokensResponse], error)
 	RevokeAPIToken(context.Context, *connect.Request[v1.RevokeAPITokenRequest]) (*connect.Response[v1.RevokeAPITokenResponse], error)
+	BatchGetUsers(context.Context, *connect.Request[v1.BatchGetUsersRequest]) (*connect.Response[v1.BatchGetUsersResponse], error)
 }
 
 // NewUsersGatewayClient constructs a client for the agynio.api.gateway.v1.UsersGateway service. By
@@ -70,11 +68,6 @@ func NewUsersGatewayClient(httpClient connect.HTTPClient, baseURL string, opts .
 	baseURL = strings.TrimRight(baseURL, "/")
 	usersGatewayMethods := v11.File_agynio_api_gateway_v1_users_proto.Services().ByName("UsersGateway").Methods()
 	return &usersGatewayClient{
-		batchGetUsers: connect.NewClient[v1.BatchGetUsersRequest, v1.BatchGetUsersResponse](
-			httpClient,
-			baseURL+UsersGatewayBatchGetUsersProcedure,
-			connect.WithClientOptions(opts...),
-		),
 		createAPIToken: connect.NewClient[v1.CreateAPITokenRequest, v1.CreateAPITokenResponse](
 			httpClient,
 			baseURL+UsersGatewayCreateAPITokenProcedure,
@@ -93,20 +86,21 @@ func NewUsersGatewayClient(httpClient connect.HTTPClient, baseURL string, opts .
 			connect.WithSchema(usersGatewayMethods.ByName("RevokeAPIToken")),
 			connect.WithClientOptions(opts...),
 		),
+		batchGetUsers: connect.NewClient[v1.BatchGetUsersRequest, v1.BatchGetUsersResponse](
+			httpClient,
+			baseURL+UsersGatewayBatchGetUsersProcedure,
+			connect.WithSchema(usersGatewayMethods.ByName("BatchGetUsers")),
+			connect.WithClientOptions(opts...),
+		),
 	}
 }
 
 // usersGatewayClient implements UsersGatewayClient.
 type usersGatewayClient struct {
-	batchGetUsers  *connect.Client[v1.BatchGetUsersRequest, v1.BatchGetUsersResponse]
 	createAPIToken *connect.Client[v1.CreateAPITokenRequest, v1.CreateAPITokenResponse]
 	listAPITokens  *connect.Client[v1.ListAPITokensRequest, v1.ListAPITokensResponse]
 	revokeAPIToken *connect.Client[v1.RevokeAPITokenRequest, v1.RevokeAPITokenResponse]
-}
-
-// BatchGetUsers calls agynio.api.gateway.v1.UsersGateway.BatchGetUsers.
-func (c *usersGatewayClient) BatchGetUsers(ctx context.Context, req *connect.Request[v1.BatchGetUsersRequest]) (*connect.Response[v1.BatchGetUsersResponse], error) {
-	return c.batchGetUsers.CallUnary(ctx, req)
+	batchGetUsers  *connect.Client[v1.BatchGetUsersRequest, v1.BatchGetUsersResponse]
 }
 
 // CreateAPIToken calls agynio.api.gateway.v1.UsersGateway.CreateAPIToken.
@@ -124,15 +118,18 @@ func (c *usersGatewayClient) RevokeAPIToken(ctx context.Context, req *connect.Re
 	return c.revokeAPIToken.CallUnary(ctx, req)
 }
 
+// BatchGetUsers calls agynio.api.gateway.v1.UsersGateway.BatchGetUsers.
+func (c *usersGatewayClient) BatchGetUsers(ctx context.Context, req *connect.Request[v1.BatchGetUsersRequest]) (*connect.Response[v1.BatchGetUsersResponse], error) {
+	return c.batchGetUsers.CallUnary(ctx, req)
+}
+
 // UsersGatewayHandler is an implementation of the agynio.api.gateway.v1.UsersGateway service.
 type UsersGatewayHandler interface {
-	// --- Users ---
-	BatchGetUsers(context.Context, *connect.Request[v1.BatchGetUsersRequest]) (*connect.Response[v1.BatchGetUsersResponse], error)
-
 	// --- API Tokens ---
 	CreateAPIToken(context.Context, *connect.Request[v1.CreateAPITokenRequest]) (*connect.Response[v1.CreateAPITokenResponse], error)
 	ListAPITokens(context.Context, *connect.Request[v1.ListAPITokensRequest]) (*connect.Response[v1.ListAPITokensResponse], error)
 	RevokeAPIToken(context.Context, *connect.Request[v1.RevokeAPITokenRequest]) (*connect.Response[v1.RevokeAPITokenResponse], error)
+	BatchGetUsers(context.Context, *connect.Request[v1.BatchGetUsersRequest]) (*connect.Response[v1.BatchGetUsersResponse], error)
 }
 
 // NewUsersGatewayHandler builds an HTTP handler from the service implementation. It returns the
@@ -142,11 +139,6 @@ type UsersGatewayHandler interface {
 // and JSON codecs. They also support gzip compression.
 func NewUsersGatewayHandler(svc UsersGatewayHandler, opts ...connect.HandlerOption) (string, http.Handler) {
 	usersGatewayMethods := v11.File_agynio_api_gateway_v1_users_proto.Services().ByName("UsersGateway").Methods()
-	usersGatewayBatchGetUsersHandler := connect.NewUnaryHandler(
-		UsersGatewayBatchGetUsersProcedure,
-		svc.BatchGetUsers,
-		connect.WithHandlerOptions(opts...),
-	)
 	usersGatewayCreateAPITokenHandler := connect.NewUnaryHandler(
 		UsersGatewayCreateAPITokenProcedure,
 		svc.CreateAPIToken,
@@ -165,16 +157,22 @@ func NewUsersGatewayHandler(svc UsersGatewayHandler, opts ...connect.HandlerOpti
 		connect.WithSchema(usersGatewayMethods.ByName("RevokeAPIToken")),
 		connect.WithHandlerOptions(opts...),
 	)
+	usersGatewayBatchGetUsersHandler := connect.NewUnaryHandler(
+		UsersGatewayBatchGetUsersProcedure,
+		svc.BatchGetUsers,
+		connect.WithSchema(usersGatewayMethods.ByName("BatchGetUsers")),
+		connect.WithHandlerOptions(opts...),
+	)
 	return "/agynio.api.gateway.v1.UsersGateway/", http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		switch r.URL.Path {
-		case UsersGatewayBatchGetUsersProcedure:
-			usersGatewayBatchGetUsersHandler.ServeHTTP(w, r)
 		case UsersGatewayCreateAPITokenProcedure:
 			usersGatewayCreateAPITokenHandler.ServeHTTP(w, r)
 		case UsersGatewayListAPITokensProcedure:
 			usersGatewayListAPITokensHandler.ServeHTTP(w, r)
 		case UsersGatewayRevokeAPITokenProcedure:
 			usersGatewayRevokeAPITokenHandler.ServeHTTP(w, r)
+		case UsersGatewayBatchGetUsersProcedure:
+			usersGatewayBatchGetUsersHandler.ServeHTTP(w, r)
 		default:
 			http.NotFound(w, r)
 		}
@@ -183,10 +181,6 @@ func NewUsersGatewayHandler(svc UsersGatewayHandler, opts ...connect.HandlerOpti
 
 // UnimplementedUsersGatewayHandler returns CodeUnimplemented from all methods.
 type UnimplementedUsersGatewayHandler struct{}
-
-func (UnimplementedUsersGatewayHandler) BatchGetUsers(context.Context, *connect.Request[v1.BatchGetUsersRequest]) (*connect.Response[v1.BatchGetUsersResponse], error) {
-	return nil, connect.NewError(connect.CodeUnimplemented, errors.New("agynio.api.gateway.v1.UsersGateway.BatchGetUsers is not implemented"))
-}
 
 func (UnimplementedUsersGatewayHandler) CreateAPIToken(context.Context, *connect.Request[v1.CreateAPITokenRequest]) (*connect.Response[v1.CreateAPITokenResponse], error) {
 	return nil, connect.NewError(connect.CodeUnimplemented, errors.New("agynio.api.gateway.v1.UsersGateway.CreateAPIToken is not implemented"))
@@ -198,4 +192,8 @@ func (UnimplementedUsersGatewayHandler) ListAPITokens(context.Context, *connect.
 
 func (UnimplementedUsersGatewayHandler) RevokeAPIToken(context.Context, *connect.Request[v1.RevokeAPITokenRequest]) (*connect.Response[v1.RevokeAPITokenResponse], error) {
 	return nil, connect.NewError(connect.CodeUnimplemented, errors.New("agynio.api.gateway.v1.UsersGateway.RevokeAPIToken is not implemented"))
+}
+
+func (UnimplementedUsersGatewayHandler) BatchGetUsers(context.Context, *connect.Request[v1.BatchGetUsersRequest]) (*connect.Response[v1.BatchGetUsersResponse], error) {
+	return nil, connect.NewError(connect.CodeUnimplemented, errors.New("agynio.api.gateway.v1.UsersGateway.BatchGetUsers is not implemented"))
 }

--- a/gen/agynio/api/gateway/v1/users.pb.go
+++ b/gen/agynio/api/gateway/v1/users.pb.go
@@ -25,11 +25,12 @@ var File_agynio_api_gateway_v1_users_proto protoreflect.FileDescriptor
 
 const file_agynio_api_gateway_v1_users_proto_rawDesc = "" +
 	"\n" +
-	"!agynio/api/gateway/v1/users.proto\x12\x15agynio.api.gateway.v1\x1a\x1fagynio/api/users/v1/users.proto2\xcc\x02\n" +
+	"!agynio/api/gateway/v1/users.proto\x12\x15agynio.api.gateway.v1\x1a\x1fagynio/api/users/v1/users.proto2\xb4\x03\n" +
 	"\fUsersGateway\x12i\n" +
 	"\x0eCreateAPIToken\x12*.agynio.api.users.v1.CreateAPITokenRequest\x1a+.agynio.api.users.v1.CreateAPITokenResponse\x12f\n" +
 	"\rListAPITokens\x12).agynio.api.users.v1.ListAPITokensRequest\x1a*.agynio.api.users.v1.ListAPITokensResponse\x12i\n" +
-	"\x0eRevokeAPIToken\x12*.agynio.api.users.v1.RevokeAPITokenRequest\x1a+.agynio.api.users.v1.RevokeAPITokenResponseB\xdd\x01\n" +
+	"\x0eRevokeAPIToken\x12*.agynio.api.users.v1.RevokeAPITokenRequest\x1a+.agynio.api.users.v1.RevokeAPITokenResponse\x12f\n" +
+	"\rBatchGetUsers\x12).agynio.api.users.v1.BatchGetUsersRequest\x1a*.agynio.api.users.v1.BatchGetUsersResponseB\xdd\x01\n" +
 	"\x19com.agynio.api.gateway.v1B\n" +
 	"UsersProtoP\x01Z=github.com/agynio/gateway/gen/agynio/api/gateway/v1;gatewayv1\xa2\x02\x03AAG\xaa\x02\x15Agynio.Api.Gateway.V1\xca\x02\x15Agynio\\Api\\Gateway\\V1\xe2\x02!Agynio\\Api\\Gateway\\V1\\GPBMetadata\xea\x02\x18Agynio::Api::Gateway::V1b\x06proto3"
 
@@ -37,19 +38,23 @@ var file_agynio_api_gateway_v1_users_proto_goTypes = []any{
 	(*v1.CreateAPITokenRequest)(nil),  // 0: agynio.api.users.v1.CreateAPITokenRequest
 	(*v1.ListAPITokensRequest)(nil),   // 1: agynio.api.users.v1.ListAPITokensRequest
 	(*v1.RevokeAPITokenRequest)(nil),  // 2: agynio.api.users.v1.RevokeAPITokenRequest
-	(*v1.CreateAPITokenResponse)(nil), // 3: agynio.api.users.v1.CreateAPITokenResponse
-	(*v1.ListAPITokensResponse)(nil),  // 4: agynio.api.users.v1.ListAPITokensResponse
-	(*v1.RevokeAPITokenResponse)(nil), // 5: agynio.api.users.v1.RevokeAPITokenResponse
+	(*v1.BatchGetUsersRequest)(nil),   // 3: agynio.api.users.v1.BatchGetUsersRequest
+	(*v1.CreateAPITokenResponse)(nil), // 4: agynio.api.users.v1.CreateAPITokenResponse
+	(*v1.ListAPITokensResponse)(nil),  // 5: agynio.api.users.v1.ListAPITokensResponse
+	(*v1.RevokeAPITokenResponse)(nil), // 6: agynio.api.users.v1.RevokeAPITokenResponse
+	(*v1.BatchGetUsersResponse)(nil),  // 7: agynio.api.users.v1.BatchGetUsersResponse
 }
 var file_agynio_api_gateway_v1_users_proto_depIdxs = []int32{
 	0, // 0: agynio.api.gateway.v1.UsersGateway.CreateAPIToken:input_type -> agynio.api.users.v1.CreateAPITokenRequest
 	1, // 1: agynio.api.gateway.v1.UsersGateway.ListAPITokens:input_type -> agynio.api.users.v1.ListAPITokensRequest
 	2, // 2: agynio.api.gateway.v1.UsersGateway.RevokeAPIToken:input_type -> agynio.api.users.v1.RevokeAPITokenRequest
-	3, // 3: agynio.api.gateway.v1.UsersGateway.CreateAPIToken:output_type -> agynio.api.users.v1.CreateAPITokenResponse
-	4, // 4: agynio.api.gateway.v1.UsersGateway.ListAPITokens:output_type -> agynio.api.users.v1.ListAPITokensResponse
-	5, // 5: agynio.api.gateway.v1.UsersGateway.RevokeAPIToken:output_type -> agynio.api.users.v1.RevokeAPITokenResponse
-	3, // [3:6] is the sub-list for method output_type
-	0, // [0:3] is the sub-list for method input_type
+	3, // 3: agynio.api.gateway.v1.UsersGateway.BatchGetUsers:input_type -> agynio.api.users.v1.BatchGetUsersRequest
+	4, // 4: agynio.api.gateway.v1.UsersGateway.CreateAPIToken:output_type -> agynio.api.users.v1.CreateAPITokenResponse
+	5, // 5: agynio.api.gateway.v1.UsersGateway.ListAPITokens:output_type -> agynio.api.users.v1.ListAPITokensResponse
+	6, // 6: agynio.api.gateway.v1.UsersGateway.RevokeAPIToken:output_type -> agynio.api.users.v1.RevokeAPITokenResponse
+	7, // 7: agynio.api.gateway.v1.UsersGateway.BatchGetUsers:output_type -> agynio.api.users.v1.BatchGetUsersResponse
+	4, // [4:8] is the sub-list for method output_type
+	0, // [0:4] is the sub-list for method input_type
 	0, // [0:0] is the sub-list for extension type_name
 	0, // [0:0] is the sub-list for extension extendee
 	0, // [0:0] is the sub-list for field type_name

--- a/gen/agynio/api/gateway/v1/users_grpc.pb.go
+++ b/gen/agynio/api/gateway/v1/users_grpc.pb.go
@@ -23,6 +23,7 @@ const (
 	UsersGateway_CreateAPIToken_FullMethodName = "/agynio.api.gateway.v1.UsersGateway/CreateAPIToken"
 	UsersGateway_ListAPITokens_FullMethodName  = "/agynio.api.gateway.v1.UsersGateway/ListAPITokens"
 	UsersGateway_RevokeAPIToken_FullMethodName = "/agynio.api.gateway.v1.UsersGateway/RevokeAPIToken"
+	UsersGateway_BatchGetUsers_FullMethodName  = "/agynio.api.gateway.v1.UsersGateway/BatchGetUsers"
 )
 
 // UsersGatewayClient is the client API for UsersGateway service.
@@ -33,6 +34,7 @@ type UsersGatewayClient interface {
 	CreateAPIToken(ctx context.Context, in *v1.CreateAPITokenRequest, opts ...grpc.CallOption) (*v1.CreateAPITokenResponse, error)
 	ListAPITokens(ctx context.Context, in *v1.ListAPITokensRequest, opts ...grpc.CallOption) (*v1.ListAPITokensResponse, error)
 	RevokeAPIToken(ctx context.Context, in *v1.RevokeAPITokenRequest, opts ...grpc.CallOption) (*v1.RevokeAPITokenResponse, error)
+	BatchGetUsers(ctx context.Context, in *v1.BatchGetUsersRequest, opts ...grpc.CallOption) (*v1.BatchGetUsersResponse, error)
 }
 
 type usersGatewayClient struct {
@@ -73,6 +75,16 @@ func (c *usersGatewayClient) RevokeAPIToken(ctx context.Context, in *v1.RevokeAP
 	return out, nil
 }
 
+func (c *usersGatewayClient) BatchGetUsers(ctx context.Context, in *v1.BatchGetUsersRequest, opts ...grpc.CallOption) (*v1.BatchGetUsersResponse, error) {
+	cOpts := append([]grpc.CallOption{grpc.StaticMethod()}, opts...)
+	out := new(v1.BatchGetUsersResponse)
+	err := c.cc.Invoke(ctx, UsersGateway_BatchGetUsers_FullMethodName, in, out, cOpts...)
+	if err != nil {
+		return nil, err
+	}
+	return out, nil
+}
+
 // UsersGatewayServer is the server API for UsersGateway service.
 // All implementations must embed UnimplementedUsersGatewayServer
 // for forward compatibility.
@@ -81,6 +93,7 @@ type UsersGatewayServer interface {
 	CreateAPIToken(context.Context, *v1.CreateAPITokenRequest) (*v1.CreateAPITokenResponse, error)
 	ListAPITokens(context.Context, *v1.ListAPITokensRequest) (*v1.ListAPITokensResponse, error)
 	RevokeAPIToken(context.Context, *v1.RevokeAPITokenRequest) (*v1.RevokeAPITokenResponse, error)
+	BatchGetUsers(context.Context, *v1.BatchGetUsersRequest) (*v1.BatchGetUsersResponse, error)
 	mustEmbedUnimplementedUsersGatewayServer()
 }
 
@@ -99,6 +112,9 @@ func (UnimplementedUsersGatewayServer) ListAPITokens(context.Context, *v1.ListAP
 }
 func (UnimplementedUsersGatewayServer) RevokeAPIToken(context.Context, *v1.RevokeAPITokenRequest) (*v1.RevokeAPITokenResponse, error) {
 	return nil, status.Error(codes.Unimplemented, "method RevokeAPIToken not implemented")
+}
+func (UnimplementedUsersGatewayServer) BatchGetUsers(context.Context, *v1.BatchGetUsersRequest) (*v1.BatchGetUsersResponse, error) {
+	return nil, status.Error(codes.Unimplemented, "method BatchGetUsers not implemented")
 }
 func (UnimplementedUsersGatewayServer) mustEmbedUnimplementedUsersGatewayServer() {}
 func (UnimplementedUsersGatewayServer) testEmbeddedByValue()                      {}
@@ -175,6 +191,24 @@ func _UsersGateway_RevokeAPIToken_Handler(srv interface{}, ctx context.Context, 
 	return interceptor(ctx, in, info, handler)
 }
 
+func _UsersGateway_BatchGetUsers_Handler(srv interface{}, ctx context.Context, dec func(interface{}) error, interceptor grpc.UnaryServerInterceptor) (interface{}, error) {
+	in := new(v1.BatchGetUsersRequest)
+	if err := dec(in); err != nil {
+		return nil, err
+	}
+	if interceptor == nil {
+		return srv.(UsersGatewayServer).BatchGetUsers(ctx, in)
+	}
+	info := &grpc.UnaryServerInfo{
+		Server:     srv,
+		FullMethod: UsersGateway_BatchGetUsers_FullMethodName,
+	}
+	handler := func(ctx context.Context, req interface{}) (interface{}, error) {
+		return srv.(UsersGatewayServer).BatchGetUsers(ctx, req.(*v1.BatchGetUsersRequest))
+	}
+	return interceptor(ctx, in, info, handler)
+}
+
 // UsersGateway_ServiceDesc is the grpc.ServiceDesc for UsersGateway service.
 // It's only intended for direct use with grpc.RegisterService,
 // and not to be introspected or modified (even as a copy)
@@ -193,6 +227,10 @@ var UsersGateway_ServiceDesc = grpc.ServiceDesc{
 		{
 			MethodName: "RevokeAPIToken",
 			Handler:    _UsersGateway_RevokeAPIToken_Handler,
+		},
+		{
+			MethodName: "BatchGetUsers",
+			Handler:    _UsersGateway_BatchGetUsers_Handler,
 		},
 	},
 	Streams:  []grpc.StreamDesc{},


### PR DESCRIPTION
## Summary
- remove the users.proto exclude from Dockerfile and CI stub generation
- regenerate gateway users stubs so the users handler is available in builds

## Testing
- nix shell nixpkgs#buf -c buf generate buf.build/agynio/api --include-imports --path agynio/api/agents/v1 --path agynio/api/apps/v1 --path agynio/api/threads/v1 --path agynio/api/chat/v1 --path agynio/api/notifications/v1 --path agynio/api/files/v1 --path agynio/api/agent_state/v1 --path agynio/api/token_counting/v1 --path agynio/api/llm/v1 --path agynio/api/secrets/v1 --path agynio/api/identity/v1 --path agynio/api/tracing/v1 --path agynio/api/users/v1 --path agynio/api/organizations/v1 --path agynio/api/ziti_management/v1 --path agynio/api/gateway/v1
- nix shell nixpkgs#go nixpkgs#gcc -c go build ./...
- nix shell nixpkgs#go nixpkgs#gcc -c go vet ./...
- nix shell nixpkgs#go nixpkgs#gcc -c go test ./...

Fixes #113