### PR TITLE
fix: update release workflow GO_VERSION to 1.25

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -63,7 +63,7 @@ jobs:
           labels: ${{ steps.meta.outputs.labels }}
           cache-from: type=gha,scope=gateway
           cache-to: type=gha,scope=gateway,mode=max
-          build-args: GO_VERSION=1.24.10
+          build-args: GO_VERSION=1.25
 
       - name: Verify multi-arch manifest
         run: |


### PR DESCRIPTION
PR #118 updated `go.mod` and the Dockerfile to Go 1.25 (required by `openziti/sdk-golang v1.6.0`), but missed updating `.github/workflows/release.yml` which had `GO_VERSION=1.24.10` hardcoded as a Docker build arg.

This caused the `v0.11.0` release image build to fail with:
```
go: go.mod requires go >= 1.25.0 (running go 1.24.10; GOTOOLCHAIN=local)
```

**Fix:** Update `build-args: GO_VERSION=1.24.10` → `GO_VERSION=1.25` in `release.yml`.