### PR TITLE
fix(ziticonn): prefer dialer identity id

### DIFF
--- a/internal/ziticonn/conn.go
+++ b/internal/ziticonn/conn.go
@@ -10,6 +10,10 @@ type SourceIdentifiable interface {
 	SourceIdentifier() string
 }
 
+type DialerIdentifiable interface {
+	GetDialerIdentityId() string
+}
+
 type contextKey struct{}
 
 func WithSourceIdentity(ctx context.Context, identity string) context.Context {
@@ -26,6 +30,12 @@ func SourceIdentityFromContext(ctx context.Context) (string, bool) {
 }
 
 func SourceIdentityFromConn(conn net.Conn) (string, bool) {
+	if dialer, ok := conn.(DialerIdentifiable); ok {
+		identity := strings.TrimSpace(dialer.GetDialerIdentityId())
+		if identity != "" {
+			return identity, true
+		}
+	}
 	source, ok := conn.(SourceIdentifiable)
 	if !ok {
 		return "", false

--- a/internal/ziticonn/conn_test.go
+++ b/internal/ziticonn/conn_test.go
@@ -1,0 +1,124 @@
+package ziticonn
+
+import (
+	"io"
+	"net"
+	"testing"
+	"time"
+)
+
+func TestSourceIdentityFromConnPrefersDialerID(t *testing.T) {
+	conn := dialerSourceConn{
+		dialerID: "  dialer-id  ",
+		sourceID: "source-name",
+	}
+
+	identity, ok := SourceIdentityFromConn(conn)
+	if !ok {
+		t.Fatalf("expected identity")
+	}
+	if identity != "dialer-id" {
+		t.Fatalf("expected dialer id, got %q", identity)
+	}
+}
+
+func TestSourceIdentityFromConnFallsBackToSourceIdentifier(t *testing.T) {
+	conn := dialerSourceConn{
+		dialerID: "   ",
+		sourceID: "  source-name  ",
+	}
+
+	identity, ok := SourceIdentityFromConn(conn)
+	if !ok {
+		t.Fatalf("expected identity")
+	}
+	if identity != "source-name" {
+		t.Fatalf("expected source identifier, got %q", identity)
+	}
+}
+
+func TestSourceIdentityFromConnSourceOnly(t *testing.T) {
+	conn := sourceConn{sourceID: "  source-name  "}
+
+	identity, ok := SourceIdentityFromConn(conn)
+	if !ok {
+		t.Fatalf("expected identity")
+	}
+	if identity != "source-name" {
+		t.Fatalf("expected source identifier, got %q", identity)
+	}
+}
+
+func TestSourceIdentityFromConnMissingIdentity(t *testing.T) {
+	_, ok := SourceIdentityFromConn(stubConn{})
+	if ok {
+		t.Fatalf("expected no identity")
+	}
+}
+
+type stubConn struct{}
+
+func (stubConn) Read([]byte) (int, error) {
+	return 0, io.EOF
+}
+
+func (stubConn) Write(data []byte) (int, error) {
+	return len(data), nil
+}
+
+func (stubConn) Close() error {
+	return nil
+}
+
+func (stubConn) LocalAddr() net.Addr {
+	return stubAddr{}
+}
+
+func (stubConn) RemoteAddr() net.Addr {
+	return stubAddr{}
+}
+
+func (stubConn) SetDeadline(time.Time) error {
+	return nil
+}
+
+func (stubConn) SetReadDeadline(time.Time) error {
+	return nil
+}
+
+func (stubConn) SetWriteDeadline(time.Time) error {
+	return nil
+}
+
+type stubAddr struct{}
+
+func (stubAddr) Network() string {
+	return "stub"
+}
+
+func (stubAddr) String() string {
+	return "stub"
+}
+
+type sourceConn struct {
+	stubConn
+	sourceID string
+}
+
+func (conn sourceConn) SourceIdentifier() string {
+	return conn.sourceID
+}
+
+type dialerSourceConn struct {
+	stubConn
+	dialerID string
+	sourceID string
+}
+
+func (conn dialerSourceConn) GetDialerIdentityId() string {
+	return conn.dialerID
+}
+
+func (conn dialerSourceConn) SourceIdentifier() string {
+	return conn.sourceID
+}


### PR DESCRIPTION
## Summary
- prefer dialer identity IDs when extracting Ziti connection identity
- add unit coverage for dialer/source fallback behavior

## Testing
- nix shell nixpkgs#go nixpkgs#gcc -c go vet ./...
- nix shell nixpkgs#go nixpkgs#gcc -c go test ./...

Closes #121