### PR TITLE
fix: retry ziti enrollment on startup

### DIFF
--- a/cmd/gateway/main.go
+++ b/cmd/gateway/main.go
@@ -17,6 +17,8 @@ import (
 	"golang.org/x/net/http2"
 	"golang.org/x/net/http2/h2c"
 	"google.golang.org/grpc"
+	"google.golang.org/grpc/codes"
+	"google.golang.org/grpc/status"
 
 	agentstatev1 "github.com/agynio/gateway/gen/agynio/api/agent_state/v1"
 	agentsv1 "github.com/agynio/gateway/gen/agynio/api/agents/v1"
@@ -48,6 +50,8 @@ const (
 	defaultAddr             = ":8080"
 	defaultZitiServiceName  = "gateway"
 	defaultAppProxyCacheTTL = 30 * time.Second
+	retryInitialBackoff     = 1 * time.Second
+	retryMaxBackoff         = 15 * time.Second
 )
 
 func main() {
@@ -207,8 +211,16 @@ func main() {
 	}
 
 	if config.ZitiEnabled {
-		zitiIdentityID, identityJSON, err := zitiMgmtClient.RequestServiceIdentity(ctx, zitimgmtv1.ServiceType_SERVICE_TYPE_GATEWAY)
-		if err != nil {
+		enrollmentCtx, cancel := context.WithTimeout(ctx, config.ZitiEnrollmentTimeout)
+		defer cancel()
+
+		var zitiIdentityID string
+		var identityJSON []byte
+		if err := retryWithBackoff(enrollmentCtx, "ziti enrollment", func(attemptCtx context.Context) error {
+			var requestErr error
+			zitiIdentityID, identityJSON, requestErr = zitiMgmtClient.RequestServiceIdentity(attemptCtx, zitimgmtv1.ServiceType_SERVICE_TYPE_GATEWAY)
+			return requestErr
+		}); err != nil {
 			log.Fatalf("failed to request ziti service identity: %v", err)
 		}
 
@@ -274,6 +286,54 @@ func zitiServiceName() string {
 		return v
 	}
 	return defaultZitiServiceName
+}
+
+func retryWithBackoff(ctx context.Context, operationName string, fn func(context.Context) error) error {
+	backoff := retryInitialBackoff
+	attempt := 1
+	for {
+		err := fn(ctx)
+		if err == nil {
+			return nil
+		}
+
+		if ctx.Err() != nil {
+			return ctx.Err()
+		}
+
+		if !isRetryableGrpcError(err) {
+			return err
+		}
+
+		delay := backoff
+		if delay > retryMaxBackoff {
+			delay = retryMaxBackoff
+		}
+
+		log.Printf("%s failed (attempt %d), retrying in %s: %v", operationName, attempt, delay, err)
+
+		timer := time.NewTimer(delay)
+		select {
+		case <-ctx.Done():
+			timer.Stop()
+			return ctx.Err()
+		case <-timer.C:
+		}
+
+		backoff *= 2
+		if backoff > retryMaxBackoff {
+			backoff = retryMaxBackoff
+		}
+		attempt++
+	}
+}
+
+func isRetryableGrpcError(err error) bool {
+	statusErr, ok := status.FromError(err)
+	if !ok {
+		return false
+	}
+	return statusErr.Code() == codes.Unavailable || statusErr.Code() == codes.Unknown
 }
 
 func mustClient[T any](target, name string, factory func(grpc.ClientConnInterface) T, cleanup *[]func()) T {

--- a/internal/platform/config.go
+++ b/internal/platform/config.go
@@ -22,6 +22,7 @@ const (
 	defaultTracingGRPCTarget        = "tracing:50051"
 	defaultZitiManagementGRPCTarget = "ziti-management:50051"
 	defaultZitiLeaseRenewalInterval = 2 * time.Minute
+	defaultZitiEnrollmentTimeout    = 2 * time.Minute
 	defaultUsersGRPCTarget          = "users:50051"
 	defaultOrganizationsGRPCTarget  = "organizations:50051"
 )
@@ -41,6 +42,7 @@ type Config struct {
 	TracingGRPCTarget        string
 	ZitiEnabled              bool
 	ZitiLeaseRenewalInterval time.Duration
+	ZitiEnrollmentTimeout    time.Duration
 	ZitiManagementGRPCTarget string
 	OIDCIssuerURL            string
 	OIDCClientID             string
@@ -65,6 +67,14 @@ func LoadConfigFromEnv() (*Config, error) {
 		return nil, fmt.Errorf("ZITI_LEASE_RENEWAL_INTERVAL must be positive")
 	}
 
+	zitiEnrollmentTimeout, err := envDuration("ZITI_ENROLLMENT_TIMEOUT", defaultZitiEnrollmentTimeout)
+	if err != nil {
+		return nil, err
+	}
+	if zitiEnrollmentTimeout <= 0 {
+		return nil, fmt.Errorf("ZITI_ENROLLMENT_TIMEOUT must be positive")
+	}
+
 	clusterAdminToken := strings.TrimSpace(os.Getenv("CLUSTER_ADMIN_TOKEN"))
 	clusterAdminIdentityID := strings.TrimSpace(os.Getenv("CLUSTER_ADMIN_IDENTITY_ID"))
 	if (clusterAdminToken == "") != (clusterAdminIdentityID == "") {
@@ -85,6 +95,7 @@ func LoadConfigFromEnv() (*Config, error) {
 		TracingGRPCTarget:        envOrDefault("TRACING_GRPC_TARGET", defaultTracingGRPCTarget),
 		ZitiEnabled:              zitiEnabled,
 		ZitiLeaseRenewalInterval: zitiLeaseRenewalInterval,
+		ZitiEnrollmentTimeout:    zitiEnrollmentTimeout,
 		ZitiManagementGRPCTarget: envOrDefault("ZITI_MANAGEMENT_GRPC_TARGET", defaultZitiManagementGRPCTarget),
 		OIDCIssuerURL:            strings.TrimSpace(os.Getenv("OIDC_ISSUER_URL")),
 		OIDCClientID:             strings.TrimSpace(os.Getenv("OIDC_CLIENT_ID")),

--- a/internal/platform/config_test.go
+++ b/internal/platform/config_test.go
@@ -20,6 +20,7 @@ func TestLoadConfigFromEnv(t *testing.T) {
 	t.Setenv("ORGANIZATIONS_GRPC_TARGET", "organizations:50062")
 	t.Setenv("ZITI_ENABLED", "true")
 	t.Setenv("ZITI_LEASE_RENEWAL_INTERVAL", "3m")
+	t.Setenv("ZITI_ENROLLMENT_TIMEOUT", "90s")
 	t.Setenv("ZITI_MANAGEMENT_GRPC_TARGET", "ziti-management:50061")
 	t.Setenv("OIDC_ISSUER_URL", "https://issuer.example.com")
 	t.Setenv("OIDC_CLIENT_ID", "client-123")
@@ -87,6 +88,10 @@ func TestLoadConfigFromEnv(t *testing.T) {
 		t.Fatalf("unexpected ziti lease renewal interval: %s", got)
 	}
 
+	if got := cfg.ZitiEnrollmentTimeout; got != 90*time.Second {
+		t.Fatalf("unexpected ziti enrollment timeout: %s", got)
+	}
+
 	if got := cfg.ZitiManagementGRPCTarget; got != "ziti-management:50061" {
 		t.Fatalf("unexpected ziti management grpc target: %s", got)
 	}
@@ -137,6 +142,7 @@ func TestLoadConfigFromEnvAllDefaults(t *testing.T) {
 	t.Setenv("ORGANIZATIONS_GRPC_TARGET", "")
 	t.Setenv("ZITI_ENABLED", "")
 	t.Setenv("ZITI_LEASE_RENEWAL_INTERVAL", "")
+	t.Setenv("ZITI_ENROLLMENT_TIMEOUT", "")
 	t.Setenv("ZITI_MANAGEMENT_GRPC_TARGET", "")
 	t.Setenv("OIDC_ISSUER_URL", "")
 	t.Setenv("OIDC_CLIENT_ID", "")
@@ -189,6 +195,9 @@ func TestLoadConfigFromEnvAllDefaults(t *testing.T) {
 	}
 	if cfg.ZitiLeaseRenewalInterval != defaultZitiLeaseRenewalInterval {
 		t.Fatalf("unexpected ziti lease renewal interval: %s", cfg.ZitiLeaseRenewalInterval)
+	}
+	if cfg.ZitiEnrollmentTimeout != defaultZitiEnrollmentTimeout {
+		t.Fatalf("unexpected ziti enrollment timeout: %s", cfg.ZitiEnrollmentTimeout)
 	}
 	if cfg.ZitiManagementGRPCTarget != defaultZitiManagementGRPCTarget {
 		t.Fatalf("unexpected ziti management grpc target: %s", cfg.ZitiManagementGRPCTarget)
@@ -269,5 +278,16 @@ func TestLoadConfigFromEnvInvalidZitiLeaseRenewalInterval(t *testing.T) {
 	_, err := LoadConfigFromEnv()
 	if err == nil {
 		t.Fatalf("expected error for invalid ziti lease renewal interval")
+	}
+}
+
+func TestLoadConfigFromEnvInvalidZitiEnrollmentTimeout(t *testing.T) {
+	t.Setenv("ZITI_ENROLLMENT_TIMEOUT", "0s")
+	t.Setenv("CLUSTER_ADMIN_TOKEN", "")
+	t.Setenv("CLUSTER_ADMIN_IDENTITY_ID", "")
+
+	_, err := LoadConfigFromEnv()
+	if err == nil {
+		t.Fatalf("expected error for invalid ziti enrollment timeout")
 	}
 }


### PR DESCRIPTION
## Summary
- add ZITI_ENROLLMENT_TIMEOUT config with validation
- retry ziti enrollment with backoff for transient gRPC failures
- cover enrollment timeout in platform config tests

## Testing
- go test ./...
- go vet ./...

Refs #126