### PR TITLE
fix: drop channel identity type

### DIFF
--- a/buf.lock
+++ b/buf.lock
@@ -2,8 +2,8 @@
 version: v2
 deps:
   - name: buf.build/agynio/api
-    commit: 95a45f717bfd40cf9fe15f1ce1411cdc
-    digest: b5:3b209b753fb3529efcc285bbd15e2c3ae69bffee76e3deb388fd2413307a01c746ead368f94b2741b59a05ac563365547d8b458404d7d27b9ab8509867ec4dea
+    commit: 8352aa52d6d24a16a83fcaac76a44348
+    digest: b5:ba596321926f259e1bec701eb2f4b918522c5e79f332b5d1c3a07629faf1de04e232a5911712a31b0ff91862d9d3e9ec264de1beb1dbe0002cdcd73a51d011d3
   - name: buf.build/opentelemetry/opentelemetry
     commit: 5f2c7d4f740541589805e0816dad4bb0
     digest: b5:935626c896cfe0f5efda467869c65df49843190c1d16ad24957d62ae840aef5f5da2474ec5c766e730b2727c6a24b39b5a2a073da70cf3f2611ce7d3934def86

--- a/internal/identity/identity.go
+++ b/internal/identity/identity.go
@@ -12,7 +12,6 @@ const (
 	IdentityTypeUser    IdentityType = "user"
 	IdentityTypeAgent   IdentityType = "agent"
 	IdentityTypeApp     IdentityType = "app"
-	IdentityTypeChannel IdentityType = "channel"
 	IdentityTypeRunner  IdentityType = "runner"
 )
 
@@ -30,8 +29,6 @@ func ParseIdentityType(value string) (IdentityType, error) {
 		return IdentityTypeAgent, nil
 	case string(IdentityTypeApp):
 		return IdentityTypeApp, nil
-	case string(IdentityTypeChannel):
-		return IdentityTypeChannel, nil
 	case string(IdentityTypeRunner):
 		return IdentityTypeRunner, nil
 	default:

--- a/internal/zitimgmtclient/client.go
+++ b/internal/zitimgmtclient/client.go
@@ -108,8 +108,6 @@ func parseIdentityType(identityType identityv1.IdentityType) (identity.IdentityT
 		return identity.IdentityTypeAgent, nil
 	case identityv1.IdentityType_IDENTITY_TYPE_RUNNER:
 		return identity.IdentityTypeRunner, nil
-	case identityv1.IdentityType_IDENTITY_TYPE_CHANNEL:
-		return identity.IdentityTypeChannel, nil
 	case identityv1.IdentityType_IDENTITY_TYPE_USER:
 		return identity.IdentityTypeUser, nil
 	case identityv1.IdentityType_IDENTITY_TYPE_APP:


### PR DESCRIPTION
## Summary
- refresh buf.lock after updating api deps
- remove channel identity handling in identity parsing and Ziti management client

## Testing
- nix shell nixpkgs#go nixpkgs#gcc -c go build ./...
- nix shell nixpkgs#go nixpkgs#gcc -c go test ./...
- nix shell nixpkgs#go nixpkgs#gcc -c go vet ./...

#128