### PR TITLE
Add console-app handler logic

### DIFF
--- a/internal/gateway/organizations.go
+++ b/internal/gateway/organizations.go
@@ -121,6 +121,10 @@ func (g *OrganizationsGateway) ListMembers(ctx context.Context, req *connect.Req
 }
 
 func (g *OrganizationsGateway) ListMyMemberships(ctx context.Context, req *connect.Request[organizationsv1.ListMyMembershipsRequest]) (*connect.Response[organizationsv1.ListMyMembershipsResponse], error) {
+	if _, ok := identity.IdentityFromContext(ctx); !ok {
+		return nil, toConnectError(status.Error(codes.Unauthenticated, "identity not available"))
+	}
+
 	resp, err := g.organizations.ListMyMemberships(ctx, req.Msg)
 	if err != nil {
 		return nil, toConnectError(err)

--- a/internal/gateway/organizations_test.go
+++ b/internal/gateway/organizations_test.go
@@ -17,6 +17,10 @@ type fakeOrganizationsClient struct {
 	listAccessibleResp  *organizationsv1.ListAccessibleOrganizationsResponse
 	listAccessibleErr   error
 	listAccessibleCalls int
+	listMyMembershipsReq   *organizationsv1.ListMyMembershipsRequest
+	listMyMembershipsResp  *organizationsv1.ListMyMembershipsResponse
+	listMyMembershipsErr   error
+	listMyMembershipsCalls int
 }
 
 func (f *fakeOrganizationsClient) CreateOrganization(ctx context.Context, in *organizationsv1.CreateOrganizationRequest, opts ...grpc.CallOption) (*organizationsv1.CreateOrganizationResponse, error) {
@@ -76,7 +80,15 @@ func (f *fakeOrganizationsClient) ListMembers(ctx context.Context, in *organizat
 }
 
 func (f *fakeOrganizationsClient) ListMyMemberships(ctx context.Context, in *organizationsv1.ListMyMembershipsRequest, opts ...grpc.CallOption) (*organizationsv1.ListMyMembershipsResponse, error) {
-	return nil, status.Error(codes.Unimplemented, "ListMyMemberships not implemented")
+	f.listMyMembershipsCalls++
+	f.listMyMembershipsReq = in
+	if f.listMyMembershipsErr != nil {
+		return nil, f.listMyMembershipsErr
+	}
+	if f.listMyMembershipsResp == nil {
+		f.listMyMembershipsResp = &organizationsv1.ListMyMembershipsResponse{}
+	}
+	return f.listMyMembershipsResp, nil
 }
 
 func TestOrganizationsGatewayListAccessibleOrganizations(t *testing.T) {
@@ -130,5 +142,56 @@ func TestOrganizationsGatewayListAccessibleOrganizationsMissingIdentity(t *testi
 	}
 	if client.listAccessibleCalls != 0 {
 		t.Fatalf("expected list accessible to not be called, got %d", client.listAccessibleCalls)
+	}
+}
+
+func TestListMyMemberships_MissingIdentity(t *testing.T) {
+	client := &fakeOrganizationsClient{}
+	gateway := NewOrganizationsGateway(client)
+
+	req := connect.NewRequest(&organizationsv1.ListMyMembershipsRequest{})
+	resp, err := gateway.ListMyMemberships(context.Background(), req)
+	if err == nil {
+		t.Fatalf("expected error")
+	}
+	if connect.CodeOf(err) != connect.CodeUnauthenticated {
+		t.Fatalf("expected CodeUnauthenticated, got %v", connect.CodeOf(err))
+	}
+	if resp != nil {
+		t.Fatalf("expected no response")
+	}
+	if client.listMyMembershipsCalls != 0 {
+		t.Fatalf("expected list my memberships to not be called, got %d", client.listMyMembershipsCalls)
+	}
+}
+
+func TestListMyMemberships_Success(t *testing.T) {
+	resolved := identity.ResolvedIdentity{
+		IdentityID:   "identity-1",
+		IdentityType: identity.IdentityTypeUser,
+	}
+	ctx := identity.WithIdentity(context.Background(), resolved)
+
+	client := &fakeOrganizationsClient{
+		listMyMembershipsResp: &organizationsv1.ListMyMembershipsResponse{},
+	}
+	gateway := NewOrganizationsGateway(client)
+
+	req := connect.NewRequest(&organizationsv1.ListMyMembershipsRequest{})
+	resp, err := gateway.ListMyMemberships(ctx, req)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if resp == nil {
+		t.Fatalf("expected response")
+	}
+	if client.listMyMembershipsCalls != 1 {
+		t.Fatalf("expected list my memberships to be called once, got %d", client.listMyMembershipsCalls)
+	}
+	if client.listMyMembershipsReq != req.Msg {
+		t.Fatalf("expected request to be forwarded")
+	}
+	if resp.Msg != client.listMyMembershipsResp {
+		t.Fatalf("expected response to be forwarded")
 	}
 }

--- a/internal/gateway/users.go
+++ b/internal/gateway/users.go
@@ -2,9 +2,13 @@ package gateway
 
 import (
 	"context"
+	"strings"
 
 	"connectrpc.com/connect"
 	usersv1 "github.com/agynio/gateway/gen/agynio/api/users/v1"
+	"github.com/agynio/gateway/internal/identity"
+	"google.golang.org/grpc/codes"
+	"google.golang.org/grpc/status"
 )
 
 type UsersGateway struct {
@@ -16,18 +20,49 @@ func NewUsersGateway(users usersv1.UsersServiceClient) *UsersGateway {
 }
 
 func (g *UsersGateway) GetMe(ctx context.Context, req *connect.Request[usersv1.GetMeRequest]) (*connect.Response[usersv1.GetMeResponse], error) {
-	resp, err := g.users.GetMe(ctx, req.Msg)
+	resolvedIdentity, ok := identity.IdentityFromContext(ctx)
+	if !ok {
+		return nil, toConnectError(status.Error(codes.Unauthenticated, "identity not available"))
+	}
+
+	userResp, err := g.users.GetUser(ctx, &usersv1.GetUserRequest{IdentityId: resolvedIdentity.IdentityID})
 	if err != nil {
 		return nil, toConnectError(err)
+	}
+
+	clusterRole := userResp.ClusterRole
+	if clusterRole == usersv1.ClusterRole_CLUSTER_ROLE_UNSPECIFIED {
+		clusterRole = usersv1.ClusterRole_CLUSTER_ROLE_ADMIN
+	}
+
+	resp := &usersv1.GetMeResponse{
+		User:        userResp.User,
+		ClusterRole: clusterRole,
 	}
 	return connect.NewResponse(resp), nil
 }
 
 func (g *UsersGateway) CreateUser(ctx context.Context, req *connect.Request[usersv1.CreateUserRequest]) (*connect.Response[usersv1.CreateUserResponse], error) {
-	resp, err := g.users.CreateUser(ctx, req.Msg)
+	oidcSubject := strings.TrimSpace(req.Msg.GetOidcSubject())
+	if oidcSubject == "" {
+		return nil, toConnectError(status.Error(codes.InvalidArgument, "oidc_subject is required"))
+	}
+
+	name := req.Msg.GetName()
+	createResp, err := g.users.ResolveOrCreateUser(ctx, &usersv1.ResolveOrCreateUserRequest{
+		OidcSubject: oidcSubject,
+		Name:        name,
+		Email:       name,
+		PhotoUrl:    req.Msg.GetPhotoUrl(),
+	})
 	if err != nil {
 		return nil, toConnectError(err)
 	}
+	if createResp == nil || createResp.User == nil {
+		return nil, toConnectError(status.Error(codes.Internal, "user missing from response"))
+	}
+
+	resp := &usersv1.CreateUserResponse{User: createResp.User}
 	return connect.NewResponse(resp), nil
 }
 

--- a/internal/gateway/users_test.go
+++ b/internal/gateway/users_test.go
@@ -6,12 +6,21 @@ import (
 
 	"connectrpc.com/connect"
 	usersv1 "github.com/agynio/gateway/gen/agynio/api/users/v1"
+	"github.com/agynio/gateway/internal/identity"
 	"google.golang.org/grpc"
 	"google.golang.org/grpc/codes"
 	"google.golang.org/grpc/status"
 )
 
 type fakeUsersClient struct {
+	resolveReq   *usersv1.ResolveOrCreateUserRequest
+	resolveResp  *usersv1.ResolveOrCreateUserResponse
+	resolveErr   error
+	resolveCalls int
+	getUserReq   *usersv1.GetUserRequest
+	getUserResp  *usersv1.GetUserResponse
+	getUserErr   error
+	getUserCalls int
 	batchGetUsersReq   *usersv1.BatchGetUsersRequest
 	batchGetUsersResp  *usersv1.BatchGetUsersResponse
 	batchGetUsersErr   error
@@ -19,11 +28,27 @@ type fakeUsersClient struct {
 }
 
 func (f *fakeUsersClient) ResolveOrCreateUser(ctx context.Context, in *usersv1.ResolveOrCreateUserRequest, opts ...grpc.CallOption) (*usersv1.ResolveOrCreateUserResponse, error) {
-	return nil, status.Error(codes.Unimplemented, "ResolveOrCreateUser not implemented")
+	f.resolveCalls++
+	f.resolveReq = in
+	if f.resolveErr != nil {
+		return nil, f.resolveErr
+	}
+	if f.resolveResp == nil {
+		f.resolveResp = &usersv1.ResolveOrCreateUserResponse{}
+	}
+	return f.resolveResp, nil
 }
 
 func (f *fakeUsersClient) GetUser(ctx context.Context, in *usersv1.GetUserRequest, opts ...grpc.CallOption) (*usersv1.GetUserResponse, error) {
-	return nil, status.Error(codes.Unimplemented, "GetUser not implemented")
+	f.getUserCalls++
+	f.getUserReq = in
+	if f.getUserErr != nil {
+		return nil, f.getUserErr
+	}
+	if f.getUserResp == nil {
+		f.getUserResp = &usersv1.GetUserResponse{}
+	}
+	return f.getUserResp, nil
 }
 
 func (f *fakeUsersClient) GetUserByOIDCSubject(ctx context.Context, in *usersv1.GetUserByOIDCSubjectRequest, opts ...grpc.CallOption) (*usersv1.GetUserByOIDCSubjectResponse, error) {
@@ -76,6 +101,180 @@ func (f *fakeUsersClient) RevokeAPIToken(ctx context.Context, in *usersv1.Revoke
 
 func (f *fakeUsersClient) ResolveAPIToken(ctx context.Context, in *usersv1.ResolveAPITokenRequest, opts ...grpc.CallOption) (*usersv1.ResolveAPITokenResponse, error) {
 	return nil, status.Error(codes.Unimplemented, "ResolveAPIToken not implemented")
+}
+
+func TestGetMe_Success(t *testing.T) {
+	resolved := identity.ResolvedIdentity{
+		IdentityID:   "identity-1",
+		IdentityType: identity.IdentityTypeUser,
+	}
+	ctx := identity.WithIdentity(context.Background(), resolved)
+
+	client := &fakeUsersClient{
+		getUserResp: &usersv1.GetUserResponse{
+			User:        &usersv1.User{Meta: &usersv1.EntityMeta{Id: "user-1"}, Name: "Ada"},
+			ClusterRole: usersv1.ClusterRole_CLUSTER_ROLE_ADMIN,
+		},
+	}
+	gateway := NewUsersGateway(client)
+
+	req := connect.NewRequest(&usersv1.GetMeRequest{})
+	resp, err := gateway.GetMe(ctx, req)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if resp == nil {
+		t.Fatalf("expected response")
+	}
+	if client.getUserCalls != 1 {
+		t.Fatalf("expected get user to be called once, got %d", client.getUserCalls)
+	}
+	if client.getUserReq == nil {
+		t.Fatalf("expected get user request")
+	}
+	if client.getUserReq.IdentityId != resolved.IdentityID {
+		t.Fatalf("expected identity_id %q, got %q", resolved.IdentityID, client.getUserReq.IdentityId)
+	}
+	if resp.Msg.User != client.getUserResp.User {
+		t.Fatalf("expected user to be forwarded")
+	}
+	if resp.Msg.ClusterRole != client.getUserResp.ClusterRole {
+		t.Fatalf("expected cluster role %v, got %v", client.getUserResp.ClusterRole, resp.Msg.ClusterRole)
+	}
+}
+
+func TestGetMe_MissingIdentity(t *testing.T) {
+	client := &fakeUsersClient{}
+	gateway := NewUsersGateway(client)
+
+	req := connect.NewRequest(&usersv1.GetMeRequest{})
+	resp, err := gateway.GetMe(context.Background(), req)
+	if err == nil {
+		t.Fatalf("expected error")
+	}
+	if connect.CodeOf(err) != connect.CodeUnauthenticated {
+		t.Fatalf("expected CodeUnauthenticated, got %v", connect.CodeOf(err))
+	}
+	if resp != nil {
+		t.Fatalf("expected no response")
+	}
+	if client.getUserCalls != 0 {
+		t.Fatalf("expected get user to not be called, got %d", client.getUserCalls)
+	}
+}
+
+func TestGetMe_ClusterRoleDefault(t *testing.T) {
+	resolved := identity.ResolvedIdentity{
+		IdentityID:   "identity-1",
+		IdentityType: identity.IdentityTypeUser,
+	}
+	ctx := identity.WithIdentity(context.Background(), resolved)
+
+	client := &fakeUsersClient{
+		getUserResp: &usersv1.GetUserResponse{
+			User:        &usersv1.User{Meta: &usersv1.EntityMeta{Id: "user-2"}, Name: "Linus"},
+			ClusterRole: usersv1.ClusterRole_CLUSTER_ROLE_UNSPECIFIED,
+		},
+	}
+	gateway := NewUsersGateway(client)
+
+	req := connect.NewRequest(&usersv1.GetMeRequest{})
+	resp, err := gateway.GetMe(ctx, req)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if resp == nil {
+		t.Fatalf("expected response")
+	}
+	if resp.Msg.ClusterRole != usersv1.ClusterRole_CLUSTER_ROLE_ADMIN {
+		t.Fatalf("expected cluster role default admin, got %v", resp.Msg.ClusterRole)
+	}
+}
+
+func TestCreateUser_Success(t *testing.T) {
+	client := &fakeUsersClient{
+		resolveResp: &usersv1.ResolveOrCreateUserResponse{
+			User: &usersv1.User{Meta: &usersv1.EntityMeta{Id: "user-1"}, Name: "Ada"},
+		},
+	}
+	gateway := NewUsersGateway(client)
+
+	name := "Ada"
+	photoURL := "https://example.com/avatar.png"
+	req := connect.NewRequest(&usersv1.CreateUserRequest{
+		OidcSubject: " subject-1 ",
+		Name:        &name,
+		PhotoUrl:    &photoURL,
+	})
+	resp, err := gateway.CreateUser(context.Background(), req)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if resp == nil {
+		t.Fatalf("expected response")
+	}
+	if client.resolveCalls != 1 {
+		t.Fatalf("expected resolve-or-create to be called once, got %d", client.resolveCalls)
+	}
+	if client.resolveReq == nil {
+		t.Fatalf("expected resolve-or-create request")
+	}
+	if client.resolveReq.OidcSubject != "subject-1" {
+		t.Fatalf("expected oidc subject %q, got %q", "subject-1", client.resolveReq.OidcSubject)
+	}
+	if client.resolveReq.Name != name {
+		t.Fatalf("expected name %q, got %q", name, client.resolveReq.Name)
+	}
+	if client.resolveReq.Email != name {
+		t.Fatalf("expected email %q, got %q", name, client.resolveReq.Email)
+	}
+	if client.resolveReq.PhotoUrl != photoURL {
+		t.Fatalf("expected photo url %q, got %q", photoURL, client.resolveReq.PhotoUrl)
+	}
+	if resp.Msg.User != client.resolveResp.User {
+		t.Fatalf("expected user to be forwarded")
+	}
+}
+
+func TestCreateUser_EmptyOidcSubject(t *testing.T) {
+	client := &fakeUsersClient{}
+	gateway := NewUsersGateway(client)
+
+	name := "Ada"
+	req := connect.NewRequest(&usersv1.CreateUserRequest{OidcSubject: "  ", Name: &name})
+	resp, err := gateway.CreateUser(context.Background(), req)
+	if err == nil {
+		t.Fatalf("expected error")
+	}
+	if connect.CodeOf(err) != connect.CodeInvalidArgument {
+		t.Fatalf("expected CodeInvalidArgument, got %v", connect.CodeOf(err))
+	}
+	if resp != nil {
+		t.Fatalf("expected no response")
+	}
+	if client.resolveCalls != 0 {
+		t.Fatalf("expected resolve-or-create to not be called, got %d", client.resolveCalls)
+	}
+}
+
+func TestCreateUser_NilUserResponse(t *testing.T) {
+	client := &fakeUsersClient{resolveResp: &usersv1.ResolveOrCreateUserResponse{}}
+	gateway := NewUsersGateway(client)
+
+	req := connect.NewRequest(&usersv1.CreateUserRequest{OidcSubject: "subject-1"})
+	resp, err := gateway.CreateUser(context.Background(), req)
+	if err == nil {
+		t.Fatalf("expected error")
+	}
+	if connect.CodeOf(err) != connect.CodeInternal {
+		t.Fatalf("expected CodeInternal, got %v", connect.CodeOf(err))
+	}
+	if resp != nil {
+		t.Fatalf("expected no response")
+	}
+	if client.resolveCalls != 1 {
+		t.Fatalf("expected resolve-or-create to be called once, got %d", client.resolveCalls)
+	}
 }
 
 func TestUsersGatewayBatchGetUsers(t *testing.T) {


### PR DESCRIPTION
## Summary
- rewrite users GetMe/CreateUser to use identity and resolve-or-create flow with cluster role defaulting
- guard ListMyMemberships behind authenticated identity
- add gateway tests for GetMe/CreateUser/ListMyMemberships handling

## Testing
- nix shell nixpkgs#go nixpkgs#gcc -c go vet ./...
- nix shell nixpkgs#go nixpkgs#gcc -c go test ./...
- nix shell nixpkgs#go nixpkgs#gcc -c go test ./... -json > /tmp/gateway-go-test.json

Closes #136