### PR TITLE
Fix Ziti identity re-enrollment

### DIFF
--- a/cmd/gateway/main.go
+++ b/cmd/gateway/main.go
@@ -8,6 +8,7 @@ import (
 	"net/http"
 	"os"
 	"strings"
+	"sync"
 	"time"
 
 	"connectrpc.com/connect"
@@ -216,10 +217,13 @@ func main() {
 			return zitiCtx.ListenWithOptions(serviceName, ziti.DefaultListenOptions())
 		}
 
+		var zitiListenerMu sync.Mutex
 		var zitiListener net.Listener
 		onNewListener := func(listener net.Listener) {
+			zitiListenerMu.Lock()
 			oldListener := zitiListener
 			zitiListener = listener
+			zitiListenerMu.Unlock()
 			log.Printf("gateway listening on ziti service %s", serviceName)
 			go func() {
 				if err := server.Serve(listener); err != nil && !errors.Is(err, http.ErrServerClosed) {

--- a/cmd/gateway/main.go
+++ b/cmd/gateway/main.go
@@ -2,7 +2,6 @@ package main
 
 import (
 	"context"
-	"encoding/json"
 	"errors"
 	"log"
 	"net"
@@ -17,8 +16,6 @@ import (
 	"golang.org/x/net/http2"
 	"golang.org/x/net/http2/h2c"
 	"google.golang.org/grpc"
-	"google.golang.org/grpc/codes"
-	"google.golang.org/grpc/status"
 
 	agentstatev1 "github.com/agynio/gateway/gen/agynio/api/agent_state/v1"
 	agentsv1 "github.com/agynio/gateway/gen/agynio/api/agents/v1"
@@ -44,6 +41,7 @@ import (
 	"github.com/agynio/gateway/internal/oidcresolver"
 	"github.com/agynio/gateway/internal/platform"
 	"github.com/agynio/gateway/internal/ziticonn"
+	"github.com/agynio/gateway/internal/zitimanager"
 	"github.com/agynio/gateway/internal/zitimgmtclient"
 )
 
@@ -51,8 +49,6 @@ const (
 	defaultAddr             = ":8080"
 	defaultZitiServiceName  = "gateway"
 	defaultAppProxyCacheTTL = 30 * time.Second
-	retryInitialBackoff     = 1 * time.Second
-	retryMaxBackoff         = 15 * time.Second
 )
 
 func main() {
@@ -215,50 +211,53 @@ func main() {
 	}
 
 	if config.ZitiEnabled {
-		enrollmentCtx, cancel := context.WithTimeout(ctx, config.ZitiEnrollmentTimeout)
-		defer cancel()
-
-		var zitiIdentityID string
-		var identityJSON []byte
-		if err := retryWithBackoff(enrollmentCtx, "ziti enrollment", func(attemptCtx context.Context) error {
-			var requestErr error
-			zitiIdentityID, identityJSON, requestErr = zitiMgmtClient.RequestServiceIdentity(attemptCtx, zitimgmtv1.ServiceType_SERVICE_TYPE_GATEWAY)
-			return requestErr
-		}); err != nil {
-			log.Fatalf("failed to request ziti service identity: %v", err)
+		serviceName := zitiServiceName()
+		listenerFactory := func(zitiCtx ziti.Context) (net.Listener, error) {
+			return zitiCtx.ListenWithOptions(serviceName, ziti.DefaultListenOptions())
 		}
 
-		zitiConfig := &ziti.Config{}
-		if err := json.Unmarshal(identityJSON, zitiConfig); err != nil {
-			log.Fatalf("failed to parse ziti identity: %v", err)
+		var zitiListener net.Listener
+		onNewListener := func(listener net.Listener) {
+			oldListener := zitiListener
+			zitiListener = listener
+			log.Printf("gateway listening on ziti service %s", serviceName)
+			go func() {
+				if err := server.Serve(listener); err != nil && !errors.Is(err, http.ErrServerClosed) {
+					log.Fatalf("ziti server stopped: %v", err)
+				}
+			}()
+			if oldListener != nil {
+				if err := oldListener.Close(); err != nil {
+					log.Printf("failed to close ziti listener: %v", err)
+				}
+			}
 		}
 
-		zitiContext, err := ziti.NewContext(zitiConfig)
+		mgr, err := zitimanager.New(
+			ctx,
+			zitiMgmtClient,
+			zitimgmtv1.ServiceType_SERVICE_TYPE_GATEWAY,
+			config.ZitiEnrollmentTimeout,
+			config.ZitiLeaseRenewalInterval,
+			listenerFactory,
+			onNewListener,
+		)
 		if err != nil {
-			log.Fatalf("failed to create ziti context: %v", err)
+			log.Fatalf("failed to initialize ziti manager: %v", err)
 		}
-		defer zitiContext.Close()
+		defer func() {
+			if zitiCtx := mgr.ZitiContext(); zitiCtx != nil {
+				zitiCtx.Close()
+			}
+		}()
 
-		appProxyHandler := http.Handler(gateway.NewAppProxyHandler(appsClient, zitiContext, defaultAppProxyCacheTTL))
+		appProxyHandler := http.Handler(gateway.NewAppProxyHandler(appsClient, mgr, defaultAppProxyCacheTTL))
 		if zitiResolver != nil || oidcResolver != nil || apiTokenResolver != nil || clusterAdminResolver != nil {
 			appProxyHandler = gateway.NewAuthMiddleware(zitiResolver, oidcResolver, apiTokenResolver, clusterAdminResolver)(appProxyHandler)
 		}
 		mux.Handle("/apps/", appProxyHandler)
 
-		go renewLease(ctx, zitiMgmtClient, zitiIdentityID, config.ZitiLeaseRenewalInterval)
-
-		serviceName := zitiServiceName()
-		listener, err := zitiContext.ListenWithOptions(serviceName, ziti.DefaultListenOptions())
-		if err != nil {
-			log.Fatalf("failed to listen on ziti service %s: %v", serviceName, err)
-		}
-
-		log.Printf("gateway listening on ziti service %s", serviceName)
-		go func() {
-			if err := server.Serve(listener); err != nil && !errors.Is(err, http.ErrServerClosed) {
-				log.Fatalf("ziti server stopped: %v", err)
-			}
-		}()
+		go mgr.RunLeaseRenewal(ctx)
 	}
 
 	log.Printf("gateway listening on %s", addr)
@@ -267,77 +266,11 @@ func main() {
 	}
 }
 
-func renewLease(ctx context.Context, client *zitimgmtclient.Client, identityID string, interval time.Duration) {
-	ticker := time.NewTicker(interval)
-	defer ticker.Stop()
-	for {
-		select {
-		case <-ctx.Done():
-			return
-		case <-ticker.C:
-			if ctx.Err() != nil {
-				return
-			}
-			if err := client.ExtendIdentityLease(ctx, identityID); err != nil {
-				log.Printf("failed to extend ziti lease: %v", err)
-			}
-		}
-	}
-}
-
 func zitiServiceName() string {
 	if v := strings.TrimSpace(os.Getenv("ZITI_SERVICE_NAME")); v != "" {
 		return v
 	}
 	return defaultZitiServiceName
-}
-
-func retryWithBackoff(ctx context.Context, operationName string, fn func(context.Context) error) error {
-	backoff := retryInitialBackoff
-	attempt := 1
-	for {
-		err := fn(ctx)
-		if err == nil {
-			return nil
-		}
-
-		if ctx.Err() != nil {
-			return ctx.Err()
-		}
-
-		if !isRetryableGrpcError(err) {
-			return err
-		}
-
-		delay := backoff
-		if delay > retryMaxBackoff {
-			delay = retryMaxBackoff
-		}
-
-		log.Printf("%s failed (attempt %d), retrying in %s: %v", operationName, attempt, delay, err)
-
-		timer := time.NewTimer(delay)
-		select {
-		case <-ctx.Done():
-			timer.Stop()
-			return ctx.Err()
-		case <-timer.C:
-		}
-
-		backoff *= 2
-		if backoff > retryMaxBackoff {
-			backoff = retryMaxBackoff
-		}
-		attempt++
-	}
-}
-
-func isRetryableGrpcError(err error) bool {
-	statusErr, ok := status.FromError(err)
-	if !ok {
-		return false
-	}
-	return statusErr.Code() == codes.Unavailable || statusErr.Code() == codes.Unknown
 }
 
 func mustClient[T any](target, name string, factory func(grpc.ClientConnInterface) T, cleanup *[]func()) T {

--- a/internal/gateway/appproxy.go
+++ b/internal/gateway/appproxy.go
@@ -17,13 +17,13 @@ import (
 )
 
 type AppProxyHandler struct {
-	apps        appsv1.AppsServiceClient
-	zitiContext ziti.Context
-	transport   *http.Transport
-	client      *http.Client
-	cacheMu     sync.RWMutex
-	cache       map[string]cachedInstallation
-	cacheTTL    time.Duration
+	apps                appsv1.AppsServiceClient
+	zitiContextProvider ZitiContextProvider
+	transport           *http.Transport
+	client              *http.Client
+	cacheMu             sync.RWMutex
+	cache               map[string]cachedInstallation
+	cacheTTL            time.Duration
 }
 
 type resolvedInstallation struct {
@@ -36,22 +36,26 @@ type cachedInstallation struct {
 	expiresAt    time.Time
 }
 
-func NewAppProxyHandler(apps appsv1.AppsServiceClient, zitiContext ziti.Context, cacheTTL time.Duration) *AppProxyHandler {
+type ZitiContextProvider interface {
+	ZitiContext() ziti.Context
+}
+
+func NewAppProxyHandler(apps appsv1.AppsServiceClient, zitiContextProvider ZitiContextProvider, cacheTTL time.Duration) *AppProxyHandler {
 	if apps == nil {
 		panic("apps client is required")
 	}
-	if zitiContext == nil {
-		panic("ziti context is required")
+	if zitiContextProvider == nil {
+		panic("ziti context provider is required")
 	}
 	if cacheTTL <= 0 {
 		panic("cache ttl must be positive")
 	}
 
 	handler := &AppProxyHandler{
-		apps:        apps,
-		zitiContext: zitiContext,
-		cache:       make(map[string]cachedInstallation),
-		cacheTTL:    cacheTTL,
+		apps:                apps,
+		zitiContextProvider: zitiContextProvider,
+		cache:               make(map[string]cachedInstallation),
+		cacheTTL:            cacheTTL,
 	}
 	handler.transport = &http.Transport{
 		DialContext: handler.dialContext,
@@ -201,5 +205,10 @@ func (h *AppProxyHandler) dialContext(ctx context.Context, network, addr string)
 		return nil, fmt.Errorf("service address missing")
 	}
 
-	return h.zitiContext.Dial(serviceName)
+	zitiContext := h.zitiContextProvider.ZitiContext()
+	if zitiContext == nil {
+		return nil, fmt.Errorf("ziti context unavailable")
+	}
+
+	return zitiContext.Dial(serviceName)
 }

--- a/internal/gateway/appproxy.go
+++ b/internal/gateway/appproxy.go
@@ -2,6 +2,7 @@ package gateway
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"io"
 	"net"
@@ -207,7 +208,7 @@ func (h *AppProxyHandler) dialContext(ctx context.Context, network, addr string)
 
 	zitiContext := h.zitiContextProvider.ZitiContext()
 	if zitiContext == nil {
-		return nil, fmt.Errorf("ziti context unavailable")
+		return nil, errors.New("ziti context unavailable")
 	}
 
 	return zitiContext.Dial(serviceName)

--- a/internal/platform/config.go
+++ b/internal/platform/config.go
@@ -21,7 +21,7 @@ const (
 	defaultSecretsGRPCTarget        = "secrets:50051"
 	defaultTracingGRPCTarget        = "tracing:50051"
 	defaultZitiManagementGRPCTarget = "ziti-management:50051"
-	defaultZitiLeaseRenewalInterval = 1 * time.Minute
+	defaultZitiLeaseRenewalInterval = 2 * time.Minute
 	defaultZitiEnrollmentTimeout    = 2 * time.Minute
 	defaultUsersGRPCTarget          = "users:50051"
 	defaultOrganizationsGRPCTarget  = "organizations:50051"

--- a/internal/platform/config.go
+++ b/internal/platform/config.go
@@ -21,7 +21,7 @@ const (
 	defaultSecretsGRPCTarget        = "secrets:50051"
 	defaultTracingGRPCTarget        = "tracing:50051"
 	defaultZitiManagementGRPCTarget = "ziti-management:50051"
-	defaultZitiLeaseRenewalInterval = 2 * time.Minute
+	defaultZitiLeaseRenewalInterval = 1 * time.Minute
 	defaultZitiEnrollmentTimeout    = 2 * time.Minute
 	defaultUsersGRPCTarget          = "users:50051"
 	defaultOrganizationsGRPCTarget  = "organizations:50051"

--- a/internal/zitimanager/manager.go
+++ b/internal/zitimanager/manager.go
@@ -3,6 +3,7 @@ package zitimanager
 import (
 	"context"
 	"encoding/json"
+	"errors"
 	"fmt"
 	"log"
 	"net"
@@ -24,21 +25,24 @@ const (
 
 var (
 	leaseRetryBackoffs = []time.Duration{1 * time.Second, 2 * time.Second, 4 * time.Second}
+	reEnrollBackoffs   = []time.Duration{1 * time.Second, 2 * time.Second, 4 * time.Second}
 	newZitiContext     = ziti.NewContext
+	errIdentityMissing = errors.New("ziti identity id missing")
 )
 
 type ListenerFactory func(zitiCtx ziti.Context) (net.Listener, error)
 type OnNewListener func(listener net.Listener)
 
 type Manager struct {
-	mu              sync.RWMutex
-	zitiCtx         ziti.Context
-	identityID      string
-	mgmtClient      *zitimgmtclient.Client
-	serviceType     zitimgmtv1.ServiceType
-	renewalInterval time.Duration
-	enrollTimeout   time.Duration
-	appCtx          context.Context
+	mu               sync.RWMutex
+	enrollMu         sync.Mutex
+	zitiCtx          ziti.Context
+	identityID       string
+	mgmtClient       *zitimgmtclient.Client
+	serviceType      zitimgmtv1.ServiceType
+	renewalInterval  time.Duration
+	enrollTimeout    time.Duration
+	reEnrollAttempts int
 
 	listenerFactory ListenerFactory
 	onNewListener   OnNewListener
@@ -54,25 +58,25 @@ func New(
 	onNewListener OnNewListener,
 ) (*Manager, error) {
 	if appCtx == nil {
-		return nil, fmt.Errorf("app context is required")
+		return nil, errors.New("app context is required")
 	}
 	if client == nil {
-		return nil, fmt.Errorf("ziti management client is required")
+		return nil, errors.New("ziti management client is required")
 	}
 	if serviceType == zitimgmtv1.ServiceType_SERVICE_TYPE_UNSPECIFIED {
-		return nil, fmt.Errorf("service type is required")
+		return nil, errors.New("service type is required")
 	}
 	if enrollTimeout <= 0 {
-		return nil, fmt.Errorf("enroll timeout must be positive")
+		return nil, errors.New("enroll timeout must be positive")
 	}
 	if renewalInterval <= 0 {
-		return nil, fmt.Errorf("renewal interval must be positive")
+		return nil, errors.New("renewal interval must be positive")
 	}
 	if listenerFactory == nil {
-		return nil, fmt.Errorf("listener factory is required")
+		return nil, errors.New("listener factory is required")
 	}
 	if onNewListener == nil {
-		return nil, fmt.Errorf("on new listener callback is required")
+		return nil, errors.New("on new listener callback is required")
 	}
 
 	mgr := &Manager{
@@ -80,12 +84,11 @@ func New(
 		serviceType:     serviceType,
 		renewalInterval: renewalInterval,
 		enrollTimeout:   enrollTimeout,
-		appCtx:          appCtx,
 		listenerFactory: listenerFactory,
 		onNewListener:   onNewListener,
 	}
 
-	if err := mgr.reEnroll(appCtx); err != nil {
+	if err := mgr.reEnrollWithBackoff(appCtx); err != nil {
 		return nil, err
 	}
 
@@ -113,8 +116,8 @@ func (m *Manager) RunLeaseRenewal(ctx context.Context) {
 			if err == nil {
 				continue
 			}
-			if status.Code(err) == codes.NotFound {
-				if reEnrollErr := m.reEnroll(ctx); reEnrollErr != nil {
+			if errors.Is(err, errIdentityMissing) || status.Code(err) == codes.NotFound {
+				if reEnrollErr := m.reEnrollWithBackoff(ctx); reEnrollErr != nil {
 					log.Printf("failed to re-enroll ziti identity: %v", reEnrollErr)
 				}
 				continue
@@ -124,13 +127,35 @@ func (m *Manager) RunLeaseRenewal(ctx context.Context) {
 	}
 }
 
-func (m *Manager) reEnroll(ctx context.Context) error {
-	m.mu.Lock()
-	defer m.mu.Unlock()
+func (m *Manager) reEnrollWithBackoff(ctx context.Context) error {
+	m.enrollMu.Lock()
+	defer m.enrollMu.Unlock()
 
-	if m.zitiCtx != nil {
-		m.zitiCtx.Close()
-		m.zitiCtx = nil
+	if delay := m.reEnrollDelay(); delay > 0 {
+		if err := sleepWithContext(ctx, delay); err != nil {
+			return err
+		}
+	}
+
+	if err := m.reEnroll(ctx); err != nil {
+		m.reEnrollAttempts++
+		return err
+	}
+
+	m.reEnrollAttempts = 0
+	return nil
+}
+
+func (m *Manager) reEnroll(ctx context.Context) error {
+	var oldCtx ziti.Context
+	m.mu.Lock()
+	oldCtx = m.zitiCtx
+	m.zitiCtx = nil
+	m.identityID = ""
+	m.mu.Unlock()
+
+	if oldCtx != nil {
+		oldCtx.Close()
 	}
 
 	enrollmentCtx, cancel := context.WithTimeout(ctx, m.enrollTimeout)
@@ -162,8 +187,10 @@ func (m *Manager) reEnroll(ctx context.Context) error {
 		return err
 	}
 
+	m.mu.Lock()
 	m.zitiCtx = zitiCtx
 	m.identityID = identityID
+	m.mu.Unlock()
 	m.onNewListener(listener)
 
 	return nil
@@ -179,7 +206,7 @@ func (m *Manager) extendLeaseWithRetry(ctx context.Context) error {
 		}
 		identityID := m.identity()
 		if identityID == "" {
-			return fmt.Errorf("ziti identity id missing")
+			return errIdentityMissing
 		}
 		lastErr = m.mgmtClient.ExtendIdentityLease(ctx, identityID)
 		if lastErr == nil {
@@ -191,6 +218,9 @@ func (m *Manager) extendLeaseWithRetry(ctx context.Context) error {
 		if status.Code(lastErr) == codes.NotFound {
 			return lastErr
 		}
+		if !isRetryableGrpcError(lastErr) {
+			return lastErr
+		}
 	}
 
 	return lastErr
@@ -200,6 +230,17 @@ func (m *Manager) identity() string {
 	m.mu.RLock()
 	defer m.mu.RUnlock()
 	return m.identityID
+}
+
+func (m *Manager) reEnrollDelay() time.Duration {
+	if m.reEnrollAttempts <= 0 || len(reEnrollBackoffs) == 0 {
+		return 0
+	}
+	idx := m.reEnrollAttempts - 1
+	if idx >= len(reEnrollBackoffs) {
+		idx = len(reEnrollBackoffs) - 1
+	}
+	return reEnrollBackoffs[idx]
 }
 
 func retryWithBackoff(ctx context.Context, operationName string, fn func(context.Context) error) error {

--- a/internal/zitimanager/manager.go
+++ b/internal/zitimanager/manager.go
@@ -1,0 +1,258 @@
+package zitimanager
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"log"
+	"net"
+	"sync"
+	"time"
+
+	"github.com/openziti/sdk-golang/ziti"
+	"google.golang.org/grpc/codes"
+	"google.golang.org/grpc/status"
+
+	zitimgmtv1 "github.com/agynio/gateway/gen/agynio/api/ziti_management/v1"
+	"github.com/agynio/gateway/internal/zitimgmtclient"
+)
+
+const (
+	retryInitialBackoff = 1 * time.Second
+	retryMaxBackoff     = 15 * time.Second
+)
+
+var (
+	leaseRetryBackoffs = []time.Duration{1 * time.Second, 2 * time.Second, 4 * time.Second}
+	newZitiContext     = ziti.NewContext
+)
+
+type ListenerFactory func(zitiCtx ziti.Context) (net.Listener, error)
+type OnNewListener func(listener net.Listener)
+
+type Manager struct {
+	mu              sync.RWMutex
+	zitiCtx         ziti.Context
+	identityID      string
+	mgmtClient      *zitimgmtclient.Client
+	serviceType     zitimgmtv1.ServiceType
+	renewalInterval time.Duration
+	enrollTimeout   time.Duration
+	appCtx          context.Context
+
+	listenerFactory ListenerFactory
+	onNewListener   OnNewListener
+}
+
+func New(
+	appCtx context.Context,
+	client *zitimgmtclient.Client,
+	serviceType zitimgmtv1.ServiceType,
+	enrollTimeout time.Duration,
+	renewalInterval time.Duration,
+	listenerFactory ListenerFactory,
+	onNewListener OnNewListener,
+) (*Manager, error) {
+	if appCtx == nil {
+		return nil, fmt.Errorf("app context is required")
+	}
+	if client == nil {
+		return nil, fmt.Errorf("ziti management client is required")
+	}
+	if serviceType == zitimgmtv1.ServiceType_SERVICE_TYPE_UNSPECIFIED {
+		return nil, fmt.Errorf("service type is required")
+	}
+	if enrollTimeout <= 0 {
+		return nil, fmt.Errorf("enroll timeout must be positive")
+	}
+	if renewalInterval <= 0 {
+		return nil, fmt.Errorf("renewal interval must be positive")
+	}
+	if listenerFactory == nil {
+		return nil, fmt.Errorf("listener factory is required")
+	}
+	if onNewListener == nil {
+		return nil, fmt.Errorf("on new listener callback is required")
+	}
+
+	mgr := &Manager{
+		mgmtClient:      client,
+		serviceType:     serviceType,
+		renewalInterval: renewalInterval,
+		enrollTimeout:   enrollTimeout,
+		appCtx:          appCtx,
+		listenerFactory: listenerFactory,
+		onNewListener:   onNewListener,
+	}
+
+	if err := mgr.reEnroll(appCtx); err != nil {
+		return nil, err
+	}
+
+	return mgr, nil
+}
+
+func (m *Manager) ZitiContext() ziti.Context {
+	m.mu.RLock()
+	defer m.mu.RUnlock()
+	return m.zitiCtx
+}
+
+func (m *Manager) RunLeaseRenewal(ctx context.Context) {
+	ticker := time.NewTicker(m.renewalInterval)
+	defer ticker.Stop()
+	for {
+		select {
+		case <-ctx.Done():
+			return
+		case <-ticker.C:
+			if ctx.Err() != nil {
+				return
+			}
+			err := m.extendLeaseWithRetry(ctx)
+			if err == nil {
+				continue
+			}
+			if status.Code(err) == codes.NotFound {
+				if reEnrollErr := m.reEnroll(ctx); reEnrollErr != nil {
+					log.Printf("failed to re-enroll ziti identity: %v", reEnrollErr)
+				}
+				continue
+			}
+			log.Printf("failed to extend ziti lease: %v", err)
+		}
+	}
+}
+
+func (m *Manager) reEnroll(ctx context.Context) error {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+
+	if m.zitiCtx != nil {
+		m.zitiCtx.Close()
+		m.zitiCtx = nil
+	}
+
+	enrollmentCtx, cancel := context.WithTimeout(ctx, m.enrollTimeout)
+	defer cancel()
+
+	var identityID string
+	var identityJSON []byte
+	if err := retryWithBackoff(enrollmentCtx, "ziti enrollment", func(attemptCtx context.Context) error {
+		var requestErr error
+		identityID, identityJSON, requestErr = m.mgmtClient.RequestServiceIdentity(attemptCtx, m.serviceType)
+		return requestErr
+	}); err != nil {
+		return err
+	}
+
+	zitiConfig := &ziti.Config{}
+	if err := json.Unmarshal(identityJSON, zitiConfig); err != nil {
+		return fmt.Errorf("failed to parse ziti identity: %w", err)
+	}
+
+	zitiCtx, err := newZitiContext(zitiConfig)
+	if err != nil {
+		return fmt.Errorf("failed to create ziti context: %w", err)
+	}
+
+	listener, err := m.listenerFactory(zitiCtx)
+	if err != nil {
+		zitiCtx.Close()
+		return err
+	}
+
+	m.zitiCtx = zitiCtx
+	m.identityID = identityID
+	m.onNewListener(listener)
+
+	return nil
+}
+
+func (m *Manager) extendLeaseWithRetry(ctx context.Context) error {
+	var lastErr error
+	for attempt := 0; attempt <= len(leaseRetryBackoffs); attempt++ {
+		if attempt > 0 {
+			if err := sleepWithContext(ctx, leaseRetryBackoffs[attempt-1]); err != nil {
+				return err
+			}
+		}
+		identityID := m.identity()
+		if identityID == "" {
+			return fmt.Errorf("ziti identity id missing")
+		}
+		lastErr = m.mgmtClient.ExtendIdentityLease(ctx, identityID)
+		if lastErr == nil {
+			return nil
+		}
+		if ctx.Err() != nil {
+			return ctx.Err()
+		}
+		if status.Code(lastErr) == codes.NotFound {
+			return lastErr
+		}
+	}
+
+	return lastErr
+}
+
+func (m *Manager) identity() string {
+	m.mu.RLock()
+	defer m.mu.RUnlock()
+	return m.identityID
+}
+
+func retryWithBackoff(ctx context.Context, operationName string, fn func(context.Context) error) error {
+	backoff := retryInitialBackoff
+	attempt := 1
+	for {
+		err := fn(ctx)
+		if err == nil {
+			return nil
+		}
+
+		if ctx.Err() != nil {
+			return ctx.Err()
+		}
+
+		if !isRetryableGrpcError(err) {
+			return err
+		}
+
+		delay := backoff
+		if delay > retryMaxBackoff {
+			delay = retryMaxBackoff
+		}
+
+		log.Printf("%s failed (attempt %d), retrying in %s: %v", operationName, attempt, delay, err)
+
+		if err := sleepWithContext(ctx, delay); err != nil {
+			return err
+		}
+
+		backoff *= 2
+		if backoff > retryMaxBackoff {
+			backoff = retryMaxBackoff
+		}
+		attempt++
+	}
+}
+
+func isRetryableGrpcError(err error) bool {
+	statusErr, ok := status.FromError(err)
+	if !ok {
+		return false
+	}
+	return statusErr.Code() == codes.Unavailable || statusErr.Code() == codes.Unknown
+}
+
+func sleepWithContext(ctx context.Context, delay time.Duration) error {
+	timer := time.NewTimer(delay)
+	defer timer.Stop()
+	select {
+	case <-ctx.Done():
+		return ctx.Err()
+	case <-timer.C:
+		return nil
+	}
+}

--- a/internal/zitimanager/manager_test.go
+++ b/internal/zitimanager/manager_test.go
@@ -1,0 +1,311 @@
+package zitimanager
+
+import (
+	"context"
+	"net"
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/openziti/sdk-golang/ziti"
+	"google.golang.org/grpc"
+	"google.golang.org/grpc/codes"
+	"google.golang.org/grpc/status"
+
+	zitimgmtv1 "github.com/agynio/gateway/gen/agynio/api/ziti_management/v1"
+	"github.com/agynio/gateway/internal/zitimgmtclient"
+)
+
+type fakeZitiManagementServer struct {
+	zitimgmtv1.UnimplementedZitiManagementServiceServer
+	requestServiceIdentity func(context.Context, *zitimgmtv1.RequestServiceIdentityRequest) (*zitimgmtv1.RequestServiceIdentityResponse, error)
+	extendIdentityLease    func(context.Context, *zitimgmtv1.ExtendIdentityLeaseRequest) (*zitimgmtv1.ExtendIdentityLeaseResponse, error)
+}
+
+func (f *fakeZitiManagementServer) RequestServiceIdentity(ctx context.Context, req *zitimgmtv1.RequestServiceIdentityRequest) (*zitimgmtv1.RequestServiceIdentityResponse, error) {
+	if f.requestServiceIdentity != nil {
+		return f.requestServiceIdentity(ctx, req)
+	}
+	return nil, status.Error(codes.Unimplemented, "not implemented")
+}
+
+func (f *fakeZitiManagementServer) ExtendIdentityLease(ctx context.Context, req *zitimgmtv1.ExtendIdentityLeaseRequest) (*zitimgmtv1.ExtendIdentityLeaseResponse, error) {
+	if f.extendIdentityLease != nil {
+		return f.extendIdentityLease(ctx, req)
+	}
+	return nil, status.Error(codes.Unimplemented, "not implemented")
+}
+
+type fakeZitiContext struct {
+	ziti.Context
+	mu     sync.Mutex
+	closed bool
+}
+
+func (f *fakeZitiContext) Close() {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	f.closed = true
+}
+
+func (f *fakeZitiContext) Closed() bool {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	return f.closed
+}
+
+func startZitiManagementServer(t *testing.T, server *fakeZitiManagementServer) (string, func()) {
+	t.Helper()
+
+	listener, err := net.Listen("tcp", "127.0.0.1:0")
+	if err != nil {
+		t.Fatalf("failed to start listener: %v", err)
+	}
+
+	grpcServer := grpc.NewServer()
+	zitimgmtv1.RegisterZitiManagementServiceServer(grpcServer, server)
+	go func() {
+		_ = grpcServer.Serve(listener)
+	}()
+
+	return listener.Addr().String(), func() {
+		grpcServer.Stop()
+		_ = listener.Close()
+	}
+}
+
+func TestManagerNewEnrollsAndCreatesListener(t *testing.T) {
+	requestCh := make(chan zitimgmtv1.ServiceType, 1)
+	server := &fakeZitiManagementServer{
+		requestServiceIdentity: func(ctx context.Context, req *zitimgmtv1.RequestServiceIdentityRequest) (*zitimgmtv1.RequestServiceIdentityResponse, error) {
+			requestCh <- req.ServiceType
+			return &zitimgmtv1.RequestServiceIdentityResponse{
+				ZitiIdentityId: "identity-1",
+				IdentityJson:   []byte("{}"),
+			}, nil
+		},
+	}
+
+	addr, stop := startZitiManagementServer(t, server)
+	t.Cleanup(stop)
+
+	client, err := zitimgmtclient.NewClient(addr)
+	if err != nil {
+		t.Fatalf("failed to create client: %v", err)
+	}
+	t.Cleanup(func() {
+		_ = client.Close()
+	})
+
+	originalFactory := newZitiContext
+	fakeContext := &fakeZitiContext{}
+	newZitiContext = func(config *ziti.Config) (ziti.Context, error) {
+		return fakeContext, nil
+	}
+	t.Cleanup(func() {
+		newZitiContext = originalFactory
+	})
+
+	var receivedContext ziti.Context
+	var listener net.Listener
+	listenerFactory := func(zitiCtx ziti.Context) (net.Listener, error) {
+		receivedContext = zitiCtx
+		var err error
+		listener, err = net.Listen("tcp", "127.0.0.1:0")
+		if err != nil {
+			return nil, err
+		}
+		return listener, nil
+	}
+
+	onNewListenerCh := make(chan net.Listener, 1)
+	onNewListener := func(newListener net.Listener) {
+		onNewListenerCh <- newListener
+	}
+
+	mgr, err := New(
+		context.Background(),
+		client,
+		zitimgmtv1.ServiceType_SERVICE_TYPE_GATEWAY,
+		time.Second,
+		time.Second,
+		listenerFactory,
+		onNewListener,
+	)
+	if err != nil {
+		t.Fatalf("failed to create manager: %v", err)
+	}
+
+	if receivedContext != fakeContext {
+		t.Fatalf("expected listener factory to receive ziti context")
+	}
+	if mgr.ZitiContext() != fakeContext {
+		t.Fatalf("expected ziti context to be stored")
+	}
+	if mgr.identityID != "identity-1" {
+		t.Fatalf("expected identity id %q, got %q", "identity-1", mgr.identityID)
+	}
+
+	select {
+	case got := <-requestCh:
+		if got != zitimgmtv1.ServiceType_SERVICE_TYPE_GATEWAY {
+			t.Fatalf("unexpected service type: %v", got)
+		}
+	case <-time.After(time.Second):
+		t.Fatalf("expected request service identity call")
+	}
+
+	select {
+	case got := <-onNewListenerCh:
+		if got != listener {
+			t.Fatalf("expected listener callback to receive listener")
+		}
+	case <-time.After(time.Second):
+		t.Fatalf("expected on new listener callback")
+	}
+
+	if listener != nil {
+		_ = listener.Close()
+	}
+}
+
+func TestRunLeaseRenewalReenrollsOnNotFound(t *testing.T) {
+	requestCh := make(chan string, 2)
+	extendCh := make(chan string, 2)
+	identityIDs := []string{"identity-1", "identity-2"}
+	var requestMu sync.Mutex
+	var requestIndex int
+	server := &fakeZitiManagementServer{
+		requestServiceIdentity: func(ctx context.Context, req *zitimgmtv1.RequestServiceIdentityRequest) (*zitimgmtv1.RequestServiceIdentityResponse, error) {
+			requestMu.Lock()
+			idx := requestIndex
+			requestIndex++
+			requestMu.Unlock()
+			if idx >= len(identityIDs) {
+				return nil, status.Error(codes.Internal, "too many requests")
+			}
+			identityID := identityIDs[idx]
+			requestCh <- identityID
+			return &zitimgmtv1.RequestServiceIdentityResponse{
+				ZitiIdentityId: identityID,
+				IdentityJson:   []byte("{}"),
+			}, nil
+		},
+		extendIdentityLease: func(ctx context.Context, req *zitimgmtv1.ExtendIdentityLeaseRequest) (*zitimgmtv1.ExtendIdentityLeaseResponse, error) {
+			extendCh <- req.ZitiIdentityId
+			return nil, status.Error(codes.NotFound, "missing")
+		},
+	}
+
+	addr, stop := startZitiManagementServer(t, server)
+	t.Cleanup(stop)
+
+	client, err := zitimgmtclient.NewClient(addr)
+	if err != nil {
+		t.Fatalf("failed to create client: %v", err)
+	}
+	t.Cleanup(func() {
+		_ = client.Close()
+	})
+
+	originalFactory := newZitiContext
+	firstContext := &fakeZitiContext{}
+	secondContext := &fakeZitiContext{}
+	contexts := []ziti.Context{firstContext, secondContext}
+	var contextMu sync.Mutex
+	newZitiContext = func(config *ziti.Config) (ziti.Context, error) {
+		contextMu.Lock()
+		defer contextMu.Unlock()
+		if len(contexts) == 0 {
+			return nil, status.Error(codes.Internal, "no contexts available")
+		}
+		ctx := contexts[0]
+		contexts = contexts[1:]
+		return ctx, nil
+	}
+	t.Cleanup(func() {
+		newZitiContext = originalFactory
+	})
+
+	listenerCh := make(chan net.Listener, 2)
+	listenerFactory := func(zitiCtx ziti.Context) (net.Listener, error) {
+		listener, err := net.Listen("tcp", "127.0.0.1:0")
+		if err != nil {
+			return nil, err
+		}
+		listenerCh <- listener
+		return listener, nil
+	}
+
+	onNewListener := func(listener net.Listener) {}
+
+	mgr, err := New(
+		context.Background(),
+		client,
+		zitimgmtv1.ServiceType_SERVICE_TYPE_GATEWAY,
+		time.Second,
+		10*time.Millisecond,
+		listenerFactory,
+		onNewListener,
+	)
+	if err != nil {
+		t.Fatalf("failed to create manager: %v", err)
+	}
+
+	firstListener := <-listenerCh
+	if firstListener != nil {
+		defer func() {
+			_ = firstListener.Close()
+		}()
+	}
+
+	leaseCtx, cancel := context.WithCancel(context.Background())
+	t.Cleanup(cancel)
+	go mgr.RunLeaseRenewal(leaseCtx)
+
+	select {
+	case got := <-extendCh:
+		if got != "identity-1" {
+			t.Fatalf("expected extend identity for %q, got %q", "identity-1", got)
+		}
+	case <-time.After(time.Second):
+		t.Fatalf("expected extend identity lease call")
+	}
+
+	var secondListener net.Listener
+	select {
+	case secondListener = <-listenerCh:
+	case <-time.After(2 * time.Second):
+		t.Fatalf("expected re-enroll listener")
+	}
+	cancel()
+	if secondListener != nil {
+		defer func() {
+			_ = secondListener.Close()
+		}()
+	}
+
+	if mgr.ZitiContext() != secondContext {
+		t.Fatalf("expected manager to store new ziti context")
+	}
+	if !firstContext.Closed() {
+		t.Fatalf("expected old ziti context to be closed")
+	}
+
+	select {
+	case got := <-requestCh:
+		if got != "identity-1" {
+			t.Fatalf("expected first identity %q, got %q", "identity-1", got)
+		}
+	case <-time.After(time.Second):
+		t.Fatalf("expected initial enrollment")
+	}
+	select {
+	case got := <-requestCh:
+		if got != "identity-2" {
+			t.Fatalf("expected second identity %q, got %q", "identity-2", got)
+		}
+	case <-time.After(time.Second):
+		t.Fatalf("expected re-enrollment")
+	}
+}

--- a/internal/zitimanager/manager_test.go
+++ b/internal/zitimanager/manager_test.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"net"
 	"sync"
+	"sync/atomic"
 	"testing"
 	"time"
 
@@ -72,6 +73,26 @@ func startZitiManagementServer(t *testing.T, server *fakeZitiManagementServer) (
 		grpcServer.Stop()
 		_ = listener.Close()
 	}
+}
+
+func setLeaseRetryBackoffs(t *testing.T, backoffs []time.Duration) {
+	t.Helper()
+
+	original := leaseRetryBackoffs
+	leaseRetryBackoffs = backoffs
+	t.Cleanup(func() {
+		leaseRetryBackoffs = original
+	})
+}
+
+func setReEnrollBackoffs(t *testing.T, backoffs []time.Duration) {
+	t.Helper()
+
+	original := reEnrollBackoffs
+	reEnrollBackoffs = backoffs
+	t.Cleanup(func() {
+		reEnrollBackoffs = original
+	})
 }
 
 func TestManagerNewEnrollsAndCreatesListener(t *testing.T) {
@@ -307,5 +328,280 @@ func TestRunLeaseRenewalReenrollsOnNotFound(t *testing.T) {
 		}
 	case <-time.After(time.Second):
 		t.Fatalf("expected re-enrollment")
+	}
+}
+
+func TestExtendLeaseWithRetryRetriesTransientErrors(t *testing.T) {
+	setLeaseRetryBackoffs(t, []time.Duration{time.Millisecond, time.Millisecond})
+
+	var extendCalls int32
+	server := &fakeZitiManagementServer{
+		requestServiceIdentity: func(ctx context.Context, req *zitimgmtv1.RequestServiceIdentityRequest) (*zitimgmtv1.RequestServiceIdentityResponse, error) {
+			return &zitimgmtv1.RequestServiceIdentityResponse{
+				ZitiIdentityId: "identity-1",
+				IdentityJson:   []byte("{}"),
+			}, nil
+		},
+		extendIdentityLease: func(ctx context.Context, req *zitimgmtv1.ExtendIdentityLeaseRequest) (*zitimgmtv1.ExtendIdentityLeaseResponse, error) {
+			call := atomic.AddInt32(&extendCalls, 1)
+			if call < 3 {
+				return nil, status.Error(codes.Unavailable, "unavailable")
+			}
+			return &zitimgmtv1.ExtendIdentityLeaseResponse{}, nil
+		},
+	}
+
+	addr, stop := startZitiManagementServer(t, server)
+	t.Cleanup(stop)
+
+	client, err := zitimgmtclient.NewClient(addr)
+	if err != nil {
+		t.Fatalf("failed to create client: %v", err)
+	}
+	t.Cleanup(func() {
+		_ = client.Close()
+	})
+
+	originalFactory := newZitiContext
+	fakeContext := &fakeZitiContext{}
+	newZitiContext = func(config *ziti.Config) (ziti.Context, error) {
+		return fakeContext, nil
+	}
+	t.Cleanup(func() {
+		newZitiContext = originalFactory
+	})
+
+	listener, err := net.Listen("tcp", "127.0.0.1:0")
+	if err != nil {
+		t.Fatalf("failed to create listener: %v", err)
+	}
+	defer func() {
+		_ = listener.Close()
+	}()
+
+	listenerFactory := func(zitiCtx ziti.Context) (net.Listener, error) {
+		return listener, nil
+	}
+
+	mgr, err := New(
+		context.Background(),
+		client,
+		zitimgmtv1.ServiceType_SERVICE_TYPE_GATEWAY,
+		time.Second,
+		time.Second,
+		listenerFactory,
+		func(net.Listener) {},
+	)
+	if err != nil {
+		t.Fatalf("failed to create manager: %v", err)
+	}
+
+	if err := mgr.extendLeaseWithRetry(context.Background()); err != nil {
+		t.Fatalf("expected retry to succeed: %v", err)
+	}
+	if got := atomic.LoadInt32(&extendCalls); got != 3 {
+		t.Fatalf("expected 3 extend attempts, got %d", got)
+	}
+}
+
+func TestExtendLeaseWithRetryStopsOnNonRetryable(t *testing.T) {
+	setLeaseRetryBackoffs(t, []time.Duration{time.Millisecond, time.Millisecond})
+
+	var extendCalls int32
+	server := &fakeZitiManagementServer{
+		requestServiceIdentity: func(ctx context.Context, req *zitimgmtv1.RequestServiceIdentityRequest) (*zitimgmtv1.RequestServiceIdentityResponse, error) {
+			return &zitimgmtv1.RequestServiceIdentityResponse{
+				ZitiIdentityId: "identity-1",
+				IdentityJson:   []byte("{}"),
+			}, nil
+		},
+		extendIdentityLease: func(ctx context.Context, req *zitimgmtv1.ExtendIdentityLeaseRequest) (*zitimgmtv1.ExtendIdentityLeaseResponse, error) {
+			atomic.AddInt32(&extendCalls, 1)
+			return nil, status.Error(codes.PermissionDenied, "denied")
+		},
+	}
+
+	addr, stop := startZitiManagementServer(t, server)
+	t.Cleanup(stop)
+
+	client, err := zitimgmtclient.NewClient(addr)
+	if err != nil {
+		t.Fatalf("failed to create client: %v", err)
+	}
+	t.Cleanup(func() {
+		_ = client.Close()
+	})
+
+	originalFactory := newZitiContext
+	fakeContext := &fakeZitiContext{}
+	newZitiContext = func(config *ziti.Config) (ziti.Context, error) {
+		return fakeContext, nil
+	}
+	t.Cleanup(func() {
+		newZitiContext = originalFactory
+	})
+
+	listener, err := net.Listen("tcp", "127.0.0.1:0")
+	if err != nil {
+		t.Fatalf("failed to create listener: %v", err)
+	}
+	defer func() {
+		_ = listener.Close()
+	}()
+
+	listenerFactory := func(zitiCtx ziti.Context) (net.Listener, error) {
+		return listener, nil
+	}
+
+	mgr, err := New(
+		context.Background(),
+		client,
+		zitimgmtv1.ServiceType_SERVICE_TYPE_GATEWAY,
+		time.Second,
+		time.Second,
+		listenerFactory,
+		func(net.Listener) {},
+	)
+	if err != nil {
+		t.Fatalf("failed to create manager: %v", err)
+	}
+
+	err = mgr.extendLeaseWithRetry(context.Background())
+	if status.Code(err) != codes.PermissionDenied {
+		t.Fatalf("expected permission denied, got %v", err)
+	}
+	if got := atomic.LoadInt32(&extendCalls); got != 1 {
+		t.Fatalf("expected 1 extend attempt, got %d", got)
+	}
+}
+
+func TestRunLeaseRenewalReenrollsAfterFailureWithBackoff(t *testing.T) {
+	setLeaseRetryBackoffs(t, []time.Duration{time.Millisecond})
+	setReEnrollBackoffs(t, []time.Duration{20 * time.Millisecond})
+
+	requestTimes := make(chan time.Time, 4)
+	var requestCalls int32
+	server := &fakeZitiManagementServer{
+		requestServiceIdentity: func(ctx context.Context, req *zitimgmtv1.RequestServiceIdentityRequest) (*zitimgmtv1.RequestServiceIdentityResponse, error) {
+			call := atomic.AddInt32(&requestCalls, 1)
+			requestTimes <- time.Now()
+			switch call {
+			case 1:
+				return &zitimgmtv1.RequestServiceIdentityResponse{
+					ZitiIdentityId: "identity-1",
+					IdentityJson:   []byte("{}"),
+				}, nil
+			case 2:
+				return nil, status.Error(codes.PermissionDenied, "denied")
+			case 3:
+				return &zitimgmtv1.RequestServiceIdentityResponse{
+					ZitiIdentityId: "identity-2",
+					IdentityJson:   []byte("{}"),
+				}, nil
+			default:
+				return nil, status.Error(codes.Internal, "too many requests")
+			}
+		},
+		extendIdentityLease: func(ctx context.Context, req *zitimgmtv1.ExtendIdentityLeaseRequest) (*zitimgmtv1.ExtendIdentityLeaseResponse, error) {
+			return nil, status.Error(codes.NotFound, "missing")
+		},
+	}
+
+	addr, stop := startZitiManagementServer(t, server)
+	t.Cleanup(stop)
+
+	client, err := zitimgmtclient.NewClient(addr)
+	if err != nil {
+		t.Fatalf("failed to create client: %v", err)
+	}
+	t.Cleanup(func() {
+		_ = client.Close()
+	})
+
+	originalFactory := newZitiContext
+	firstContext := &fakeZitiContext{}
+	secondContext := &fakeZitiContext{}
+	contexts := []ziti.Context{firstContext, secondContext}
+	var contextMu sync.Mutex
+	newZitiContext = func(config *ziti.Config) (ziti.Context, error) {
+		contextMu.Lock()
+		defer contextMu.Unlock()
+		if len(contexts) == 0 {
+			return nil, status.Error(codes.Internal, "no contexts available")
+		}
+		ctx := contexts[0]
+		contexts = contexts[1:]
+		return ctx, nil
+	}
+	t.Cleanup(func() {
+		newZitiContext = originalFactory
+	})
+
+	listenerCh := make(chan net.Listener, 2)
+	listenerFactory := func(zitiCtx ziti.Context) (net.Listener, error) {
+		return net.Listen("tcp", "127.0.0.1:0")
+	}
+	onNewListener := func(listener net.Listener) {
+		listenerCh <- listener
+	}
+
+	mgr, err := New(
+		context.Background(),
+		client,
+		zitimgmtv1.ServiceType_SERVICE_TYPE_GATEWAY,
+		time.Second,
+		5*time.Millisecond,
+		listenerFactory,
+		onNewListener,
+	)
+	if err != nil {
+		t.Fatalf("failed to create manager: %v", err)
+	}
+
+	select {
+	case listener := <-listenerCh:
+		defer func(l net.Listener) {
+			_ = l.Close()
+		}(listener)
+	case <-time.After(time.Second):
+		t.Fatalf("expected initial listener")
+	}
+
+	leaseCtx, cancel := context.WithTimeout(context.Background(), time.Second)
+	go mgr.RunLeaseRenewal(leaseCtx)
+
+	var times []time.Time
+	for i := 0; i < 3; i++ {
+		select {
+		case timestamp := <-requestTimes:
+			times = append(times, timestamp)
+		case <-time.After(time.Second):
+			cancel()
+			t.Fatalf("expected enrollment attempt %d", i+1)
+		}
+	}
+	if len(times) == 3 {
+		delta := times[2].Sub(times[1])
+		if delta < 15*time.Millisecond {
+			t.Fatalf("expected re-enroll backoff, got %s", delta)
+		}
+	}
+
+	select {
+	case listener := <-listenerCh:
+		defer func(l net.Listener) {
+			_ = l.Close()
+		}(listener)
+	case <-time.After(time.Second):
+		t.Fatalf("expected re-enrolled listener")
+	}
+
+	cancel()
+
+	if mgr.ZitiContext() != secondContext {
+		t.Fatalf("expected manager to store new ziti context")
+	}
+	if !firstContext.Closed() {
+		t.Fatalf("expected old ziti context to be closed")
 	}
 }


### PR DESCRIPTION
## Summary
- add ZitiManager for enrollment renewal and listener rebinding
- update app proxy to fetch ziti context from the manager
- reduce default ziti lease renewal interval

## Testing
- nix shell nixpkgs#go nixpkgs#gcc -c go vet ./...
- nix shell nixpkgs#go nixpkgs#gcc -c go test ./...
- nix shell nixpkgs#go nixpkgs#gcc -c go build ./...

#108