### PR TITLE
feat(gateway): forward metering usage

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -43,6 +43,7 @@ jobs:
             --path agynio/api/files/v1 \
             --path agynio/api/agent_state/v1 \
             --path agynio/api/token_counting/v1 \
+            --path agynio/api/metering/v1 \
             --path agynio/api/llm/v1 \
             --path agynio/api/secrets/v1 \
             --path agynio/api/identity/v1 \

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -27,8 +27,7 @@ jobs:
         uses: bufbuild/buf-setup-action@v1
         with:
           version: '1.66.1'
-          github_token: ${{ secrets.GITHUB_TOKEN }}
-          buf_api_token: ${{ secrets.BUF_TOKEN }}
+          buf_token: ${{ secrets.BUF_TOKEN }}
 
       - name: Generate gRPC stubs
         env:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -27,7 +27,8 @@ jobs:
         uses: bufbuild/buf-setup-action@v1
         with:
           version: '1.66.1'
-          buf_token: ${{ secrets.BUF_TOKEN }}
+          github_token: ${{ secrets.GITHUB_TOKEN }}
+          buf_api_token: ${{ secrets.BUF_TOKEN }}
 
       - name: Generate gRPC stubs
         env:

--- a/Dockerfile
+++ b/Dockerfile
@@ -35,6 +35,7 @@ RUN buf generate buf.build/agynio/api \
       --path agynio/api/files/v1 \
       --path agynio/api/agent_state/v1 \
       --path agynio/api/token_counting/v1 \
+      --path agynio/api/metering/v1 \
       --path agynio/api/llm/v1 \
       --path agynio/api/secrets/v1 \
       --path agynio/api/identity/v1 \

--- a/charts/gateway/templates/_helpers.tpl
+++ b/charts/gateway/templates/_helpers.tpl
@@ -25,6 +25,9 @@
 {{- $tokenCountingGrpcTarget := trimAll " \n\t" (default "" .Values.gateway.tokenCountingGrpcTarget) -}}
 {{- $env = append $env (dict "name" "TOKEN_COUNTING_GRPC_TARGET" "value" $tokenCountingGrpcTarget) -}}
 
+{{- $meteringGrpcTarget := trimAll " \n\t" (default "" .Values.gateway.meteringGrpcTarget) -}}
+{{- $env = append $env (dict "name" "METERING_GRPC_TARGET" "value" $meteringGrpcTarget) -}}
+
 {{- $secretsGrpcTarget := trimAll " \n\t" (default "" .Values.gateway.secretsGrpcTarget) -}}
 {{- $env = append $env (dict "name" "SECRETS_GRPC_TARGET" "value" $secretsGrpcTarget) -}}
 

--- a/charts/gateway/values.yaml
+++ b/charts/gateway/values.yaml
@@ -159,6 +159,7 @@ gateway:
   filesGrpcTarget: "files:50051"
   agentStateGrpcTarget: "agent-state:50051"
   tokenCountingGrpcTarget: "token-counting:50051"
+  meteringGrpcTarget: "metering:50051"
   secretsGrpcTarget: "secrets:50051"
   usersGrpcTarget: "users:50051"
   organizationsGrpcTarget: "organizations:50051"

--- a/cmd/gateway/main.go
+++ b/cmd/gateway/main.go
@@ -26,6 +26,7 @@ import (
 	filesv1 "github.com/agynio/gateway/gen/agynio/api/files/v1"
 	"github.com/agynio/gateway/gen/agynio/api/gateway/v1/gatewayv1connect"
 	llmv1 "github.com/agynio/gateway/gen/agynio/api/llm/v1"
+	meteringv1 "github.com/agynio/gateway/gen/agynio/api/metering/v1"
 	notificationsv1 "github.com/agynio/gateway/gen/agynio/api/notifications/v1"
 	organizationsv1 "github.com/agynio/gateway/gen/agynio/api/organizations/v1"
 	runnersv1 "github.com/agynio/gateway/gen/agynio/api/runners/v1"
@@ -128,6 +129,7 @@ func main() {
 	filesClient := mustClient(config.FilesGRPCTarget, "files", filesv1.NewFilesServiceClient, &cleanup)
 	agentStateClient := mustClient(config.AgentStateGRPCTarget, "agent state", agentstatev1.NewAgentStateServiceClient, &cleanup)
 	tokenCountingClient := mustClient(config.TokenCountingGRPCTarget, "token counting", tokencountingv1.NewTokenCountingServiceClient, &cleanup)
+	meteringClient := mustClient(config.MeteringGRPCTarget, "metering", meteringv1.NewMeteringServiceClient, &cleanup)
 	llmClient := mustClient(config.LLMGRPCTarget, "llm", llmv1.NewLLMServiceClient, &cleanup)
 	secretsClient := mustClient(config.SecretsGRPCTarget, "secrets", secretsv1.NewSecretsServiceClient, &cleanup)
 	tracingClient := mustClient(config.TracingGRPCTarget, "tracing", tracingv1.NewTracingServiceClient, &cleanup)
@@ -150,6 +152,7 @@ func main() {
 	usersGateway := gateway.NewUsersGateway(usersClient)
 	organizationsGateway := gateway.NewOrganizationsGateway(organizationsClient)
 	runnersGateway := gateway.NewRunnersGateway(runnersClient)
+	meteringGateway := gateway.NewMeteringGateway(meteringClient)
 	exposeGateway := gateway.NewExposeGateway(exposeClient)
 
 	interceptors := []connect.Interceptor{
@@ -181,6 +184,7 @@ func main() {
 	registerConnect(gatewayv1connect.NewFilesGatewayHandler(gatewayHandler, handlerOptions))
 	registerConnect(gatewayv1connect.NewAgentStateGatewayHandler(gatewayHandler, handlerOptions))
 	registerConnect(gatewayv1connect.NewTokenCountingGatewayHandler(gatewayHandler, handlerOptions))
+	registerConnect(gatewayv1connect.NewMeteringGatewayHandler(meteringGateway, handlerOptions))
 	registerConnect(gatewayv1connect.NewLLMGatewayHandler(gatewayHandler, handlerOptions))
 	registerConnect(gatewayv1connect.NewSecretsGatewayHandler(gatewayHandler, handlerOptions))
 	registerConnect(gatewayv1connect.NewTracingGatewayHandler(gatewayHandler, handlerOptions))

--- a/internal/gateway/metering.go
+++ b/internal/gateway/metering.go
@@ -1,0 +1,24 @@
+package gateway
+
+import (
+	"context"
+
+	"connectrpc.com/connect"
+	meteringv1 "github.com/agynio/gateway/gen/agynio/api/metering/v1"
+)
+
+type MeteringGateway struct {
+	metering meteringv1.MeteringServiceClient
+}
+
+func NewMeteringGateway(metering meteringv1.MeteringServiceClient) *MeteringGateway {
+	return &MeteringGateway{metering: metering}
+}
+
+func (g *MeteringGateway) QueryUsage(ctx context.Context, req *connect.Request[meteringv1.QueryUsageRequest]) (*connect.Response[meteringv1.QueryUsageResponse], error) {
+	resp, err := g.metering.QueryUsage(ctx, req.Msg)
+	if err != nil {
+		return nil, toConnectError(err)
+	}
+	return connect.NewResponse(resp), nil
+}

--- a/internal/platform/config.go
+++ b/internal/platform/config.go
@@ -17,6 +17,7 @@ const (
 	defaultFilesGRPCTarget          = "files:50051"
 	defaultAgentStateGRPCTarget     = "agent-state:50051"
 	defaultTokenCountingGRPCTarget  = "token-counting:50051"
+	defaultMeteringGRPCTarget       = "metering:50051"
 	defaultLLMGRPCTarget            = "llm:50051"
 	defaultSecretsGRPCTarget        = "secrets:50051"
 	defaultTracingGRPCTarget        = "tracing:50051"
@@ -39,6 +40,7 @@ type Config struct {
 	FilesGRPCTarget          string
 	AgentStateGRPCTarget     string
 	TokenCountingGRPCTarget  string
+	MeteringGRPCTarget       string
 	LLMGRPCTarget            string
 	SecretsGRPCTarget        string
 	TracingGRPCTarget        string
@@ -94,6 +96,7 @@ func LoadConfigFromEnv() (*Config, error) {
 		FilesGRPCTarget:          envOrDefault("FILES_GRPC_TARGET", defaultFilesGRPCTarget),
 		AgentStateGRPCTarget:     envOrDefault("AGENT_STATE_GRPC_TARGET", defaultAgentStateGRPCTarget),
 		TokenCountingGRPCTarget:  envOrDefault("TOKEN_COUNTING_GRPC_TARGET", defaultTokenCountingGRPCTarget),
+		MeteringGRPCTarget:       envOrDefault("METERING_GRPC_TARGET", defaultMeteringGRPCTarget),
 		LLMGRPCTarget:            envOrDefault("LLM_GRPC_TARGET", defaultLLMGRPCTarget),
 		SecretsGRPCTarget:        envOrDefault("SECRETS_GRPC_TARGET", defaultSecretsGRPCTarget),
 		TracingGRPCTarget:        envOrDefault("TRACING_GRPC_TARGET", defaultTracingGRPCTarget),

--- a/internal/platform/config_test.go
+++ b/internal/platform/config_test.go
@@ -14,6 +14,7 @@ func TestLoadConfigFromEnv(t *testing.T) {
 	t.Setenv("FILES_GRPC_TARGET", "files:50053")
 	t.Setenv("AGENT_STATE_GRPC_TARGET", "agent-state:50056")
 	t.Setenv("TOKEN_COUNTING_GRPC_TARGET", "token-counting:50057")
+	t.Setenv("METERING_GRPC_TARGET", "metering:50064")
 	t.Setenv("LLM_GRPC_TARGET", "llm:50058")
 	t.Setenv("SECRETS_GRPC_TARGET", "secrets:50059")
 	t.Setenv("USERS_GRPC_TARGET", "users:50060")
@@ -63,6 +64,10 @@ func TestLoadConfigFromEnv(t *testing.T) {
 
 	if got := cfg.TokenCountingGRPCTarget; got != "token-counting:50057" {
 		t.Fatalf("unexpected token counting grpc target: %s", got)
+	}
+
+	if got := cfg.MeteringGRPCTarget; got != "metering:50064" {
+		t.Fatalf("unexpected metering grpc target: %s", got)
 	}
 
 	if got := cfg.LLMGRPCTarget; got != "llm:50058" {
@@ -141,6 +146,7 @@ func TestLoadConfigFromEnvAllDefaults(t *testing.T) {
 	t.Setenv("FILES_GRPC_TARGET", "")
 	t.Setenv("AGENT_STATE_GRPC_TARGET", "")
 	t.Setenv("TOKEN_COUNTING_GRPC_TARGET", "")
+	t.Setenv("METERING_GRPC_TARGET", "")
 	t.Setenv("LLM_GRPC_TARGET", "")
 	t.Setenv("SECRETS_GRPC_TARGET", "")
 	t.Setenv("USERS_GRPC_TARGET", "")
@@ -183,6 +189,9 @@ func TestLoadConfigFromEnvAllDefaults(t *testing.T) {
 	}
 	if cfg.TokenCountingGRPCTarget != defaultTokenCountingGRPCTarget {
 		t.Fatalf("unexpected token counting grpc target: %s", cfg.TokenCountingGRPCTarget)
+	}
+	if cfg.MeteringGRPCTarget != defaultMeteringGRPCTarget {
+		t.Fatalf("unexpected metering grpc target: %s", cfg.MeteringGRPCTarget)
 	}
 	if cfg.LLMGRPCTarget != defaultLLMGRPCTarget {
 		t.Fatalf("unexpected llm grpc target: %s", cfg.LLMGRPCTarget)

--- a/scripts/devspace-startup.sh
+++ b/scripts/devspace-startup.sh
@@ -12,6 +12,7 @@ buf generate buf.build/agynio/api \
   --path agynio/api/files/v1 \
   --path agynio/api/agent_state/v1 \
   --path agynio/api/token_counting/v1 \
+  --path agynio/api/metering/v1 \
   --path agynio/api/llm/v1 \
   --path agynio/api/secrets/v1 \
   --path agynio/api/identity/v1 \


### PR DESCRIPTION
## Summary
- add metering gateway handler that proxies QueryUsage to the metering service
- introduce METERING_GRPC_TARGET config plus Helm value/env wiring
- include metering protos in buf generate paths

## Testing
- nix shell nixpkgs#buf -c buf generate buf.build/agynio/api --include-imports --path agynio/api/agents/v1 --path agynio/api/apps/v1 --path agynio/api/threads/v1 --path agynio/api/chat/v1 --path agynio/api/notifications/v1 --path agynio/api/files/v1 --path agynio/api/agent_state/v1 --path agynio/api/token_counting/v1 --path agynio/api/metering/v1 --path agynio/api/llm/v1 --path agynio/api/secrets/v1 --path agynio/api/identity/v1 --path agynio/api/tracing/v1 --path agynio/api/users/v1 --path agynio/api/organizations/v1 --path agynio/api/runners/v1 --path agynio/api/expose/v1 --path agynio/api/ziti_management/v1 --path agynio/api/gateway/v1
- CGO_ENABLED=0 go vet ./...
- CGO_ENABLED=0 go test ./...
- nix shell nixpkgs#kubernetes-helm -c helm dependency build charts/gateway
- nix shell nixpkgs#kubernetes-helm -c helm lint charts/gateway

Fixes agynio/metering#1