### PR TITLE
fix(gateway): inject threads org metadata

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -22,7 +22,7 @@ RUN --mount=type=cache,target=/root/.cache/go-build \
     --mount=type=cache,target=/root/go/pkg/mod \
     go mod download && go mod verify
 
-COPY buf.gen.yaml buf.yaml ./
+COPY buf.gen.yaml buf.yaml buf.lock ./
 
 # Generate protobuf stubs
 RUN buf generate buf.build/agynio/api \

--- a/internal/gateway/threads.go
+++ b/internal/gateway/threads.go
@@ -2,9 +2,15 @@ package gateway
 
 import (
 	"context"
+	"strings"
 
 	"connectrpc.com/connect"
+	agentsv1 "github.com/agynio/gateway/gen/agynio/api/agents/v1"
 	threadsv1 "github.com/agynio/gateway/gen/agynio/api/threads/v1"
+	"github.com/agynio/gateway/internal/identity"
+	"google.golang.org/grpc/codes"
+	"google.golang.org/grpc/metadata"
+	"google.golang.org/grpc/status"
 )
 
 // ThreadsGateway forwards thread RPCs using the shared Gateway clients.
@@ -17,6 +23,10 @@ func NewThreadsGateway(gateway *Gateway) *ThreadsGateway {
 }
 
 func (g *ThreadsGateway) CreateThread(ctx context.Context, req *connect.Request[threadsv1.CreateThreadRequest]) (*connect.Response[threadsv1.CreateThreadResponse], error) {
+	ctx, err := g.withOrganizationContext(ctx)
+	if err != nil {
+		return nil, toConnectError(err)
+	}
 	resp, err := g.threads.CreateThread(ctx, req.Msg)
 	if err != nil {
 		return nil, toConnectError(err)
@@ -25,6 +35,10 @@ func (g *ThreadsGateway) CreateThread(ctx context.Context, req *connect.Request[
 }
 
 func (g *ThreadsGateway) ArchiveThread(ctx context.Context, req *connect.Request[threadsv1.ArchiveThreadRequest]) (*connect.Response[threadsv1.ArchiveThreadResponse], error) {
+	ctx, err := g.withOrganizationContext(ctx)
+	if err != nil {
+		return nil, toConnectError(err)
+	}
 	resp, err := g.threads.ArchiveThread(ctx, req.Msg)
 	if err != nil {
 		return nil, toConnectError(err)
@@ -33,6 +47,10 @@ func (g *ThreadsGateway) ArchiveThread(ctx context.Context, req *connect.Request
 }
 
 func (g *ThreadsGateway) AddParticipant(ctx context.Context, req *connect.Request[threadsv1.AddParticipantRequest]) (*connect.Response[threadsv1.AddParticipantResponse], error) {
+	ctx, err := g.withOrganizationContext(ctx)
+	if err != nil {
+		return nil, toConnectError(err)
+	}
 	resp, err := g.threads.AddParticipant(ctx, req.Msg)
 	if err != nil {
 		return nil, toConnectError(err)
@@ -41,6 +59,10 @@ func (g *ThreadsGateway) AddParticipant(ctx context.Context, req *connect.Reques
 }
 
 func (g *ThreadsGateway) SendMessage(ctx context.Context, req *connect.Request[threadsv1.SendMessageRequest]) (*connect.Response[threadsv1.SendMessageResponse], error) {
+	ctx, err := g.withOrganizationContext(ctx)
+	if err != nil {
+		return nil, toConnectError(err)
+	}
 	resp, err := g.threads.SendMessage(ctx, req.Msg)
 	if err != nil {
 		return nil, toConnectError(err)
@@ -49,6 +71,10 @@ func (g *ThreadsGateway) SendMessage(ctx context.Context, req *connect.Request[t
 }
 
 func (g *ThreadsGateway) GetThreads(ctx context.Context, req *connect.Request[threadsv1.GetThreadsRequest]) (*connect.Response[threadsv1.GetThreadsResponse], error) {
+	ctx, err := g.withOrganizationContext(ctx)
+	if err != nil {
+		return nil, toConnectError(err)
+	}
 	resp, err := g.threads.GetThreads(ctx, req.Msg)
 	if err != nil {
 		return nil, toConnectError(err)
@@ -57,6 +83,10 @@ func (g *ThreadsGateway) GetThreads(ctx context.Context, req *connect.Request[th
 }
 
 func (g *ThreadsGateway) GetMessages(ctx context.Context, req *connect.Request[threadsv1.GetMessagesRequest]) (*connect.Response[threadsv1.GetMessagesResponse], error) {
+	ctx, err := g.withOrganizationContext(ctx)
+	if err != nil {
+		return nil, toConnectError(err)
+	}
 	resp, err := g.threads.GetMessages(ctx, req.Msg)
 	if err != nil {
 		return nil, toConnectError(err)
@@ -65,6 +95,10 @@ func (g *ThreadsGateway) GetMessages(ctx context.Context, req *connect.Request[t
 }
 
 func (g *ThreadsGateway) GetUnackedMessages(ctx context.Context, req *connect.Request[threadsv1.GetUnackedMessagesRequest]) (*connect.Response[threadsv1.GetUnackedMessagesResponse], error) {
+	ctx, err := g.withOrganizationContext(ctx)
+	if err != nil {
+		return nil, toConnectError(err)
+	}
 	resp, err := g.threads.GetUnackedMessages(ctx, req.Msg)
 	if err != nil {
 		return nil, toConnectError(err)
@@ -73,9 +107,40 @@ func (g *ThreadsGateway) GetUnackedMessages(ctx context.Context, req *connect.Re
 }
 
 func (g *ThreadsGateway) AckMessages(ctx context.Context, req *connect.Request[threadsv1.AckMessagesRequest]) (*connect.Response[threadsv1.AckMessagesResponse], error) {
+	ctx, err := g.withOrganizationContext(ctx)
+	if err != nil {
+		return nil, toConnectError(err)
+	}
 	resp, err := g.threads.AckMessages(ctx, req.Msg)
 	if err != nil {
 		return nil, toConnectError(err)
 	}
 	return connect.NewResponse(resp), nil
+}
+
+func (g *ThreadsGateway) withOrganizationContext(ctx context.Context) (context.Context, error) {
+	resolved, ok := identity.IdentityFromContext(ctx)
+	if !ok {
+		return ctx, nil
+	}
+	if resolved.IdentityType != identity.IdentityTypeAgent {
+		return ctx, nil
+	}
+	identityID := strings.TrimSpace(resolved.IdentityID)
+	if identityID == "" {
+		return ctx, status.Error(codes.Unauthenticated, "identity id missing")
+	}
+	resp, err := g.agents.GetAgent(ctx, &agentsv1.GetAgentRequest{Id: identityID})
+	if err != nil {
+		return ctx, err
+	}
+	agent := resp.GetAgent()
+	if agent == nil {
+		return ctx, status.Error(codes.Internal, "agent response missing")
+	}
+	organizationID := strings.TrimSpace(agent.GetOrganizationId())
+	if organizationID == "" {
+		return ctx, status.Error(codes.Internal, "agent organization_id missing")
+	}
+	return metadata.AppendToOutgoingContext(ctx, identity.MetadataKeyOrganizationID, organizationID), nil
 }

--- a/internal/gateway/threads_test.go
+++ b/internal/gateway/threads_test.go
@@ -1,0 +1,143 @@
+package gateway
+
+import (
+	"context"
+	"testing"
+
+	agentsv1 "github.com/agynio/gateway/gen/agynio/api/agents/v1"
+	"github.com/agynio/gateway/internal/identity"
+	"google.golang.org/grpc"
+	"google.golang.org/grpc/codes"
+	"google.golang.org/grpc/metadata"
+	"google.golang.org/grpc/status"
+)
+
+type fakeAgentsClient struct {
+	agentsv1.AgentsServiceClient
+	getAgentReq   *agentsv1.GetAgentRequest
+	getAgentResp  *agentsv1.GetAgentResponse
+	getAgentErr   error
+	getAgentCalls int
+}
+
+func (f *fakeAgentsClient) GetAgent(ctx context.Context, in *agentsv1.GetAgentRequest, opts ...grpc.CallOption) (*agentsv1.GetAgentResponse, error) {
+	f.getAgentCalls++
+	f.getAgentReq = in
+	if f.getAgentErr != nil {
+		return nil, f.getAgentErr
+	}
+	if f.getAgentResp == nil {
+		f.getAgentResp = &agentsv1.GetAgentResponse{}
+	}
+	return f.getAgentResp, nil
+}
+
+func newThreadsGateway(agents agentsv1.AgentsServiceClient) *ThreadsGateway {
+	gateway := New(agents, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil)
+	return NewThreadsGateway(gateway)
+}
+
+func TestWithOrganizationContextNoIdentity(t *testing.T) {
+	client := &fakeAgentsClient{}
+	gateway := newThreadsGateway(client)
+
+	ctx := context.Background()
+	gotCtx, err := gateway.withOrganizationContext(ctx)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if gotCtx != ctx {
+		t.Fatalf("expected context to be passed through")
+	}
+	if md, ok := metadata.FromOutgoingContext(gotCtx); ok {
+		if values := md.Get(identity.MetadataKeyOrganizationID); len(values) > 0 {
+			t.Fatalf("expected no organization metadata")
+		}
+	}
+	if client.getAgentCalls != 0 {
+		t.Fatalf("expected agent not to be called, got %d", client.getAgentCalls)
+	}
+}
+
+func TestWithOrganizationContextNonAgentIdentity(t *testing.T) {
+	client := &fakeAgentsClient{}
+	gateway := newThreadsGateway(client)
+
+	ctx := identity.WithIdentity(context.Background(), identity.ResolvedIdentity{
+		IdentityID:   "user-1",
+		IdentityType: identity.IdentityTypeUser,
+	})
+	gotCtx, err := gateway.withOrganizationContext(ctx)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if gotCtx != ctx {
+		t.Fatalf("expected context to be passed through")
+	}
+	if md, ok := metadata.FromOutgoingContext(gotCtx); ok {
+		if values := md.Get(identity.MetadataKeyOrganizationID); len(values) > 0 {
+			t.Fatalf("expected no organization metadata")
+		}
+	}
+	if client.getAgentCalls != 0 {
+		t.Fatalf("expected agent not to be called, got %d", client.getAgentCalls)
+	}
+}
+
+func TestWithOrganizationContextAgentIdentity(t *testing.T) {
+	client := &fakeAgentsClient{
+		getAgentResp: &agentsv1.GetAgentResponse{
+			Agent: &agentsv1.Agent{
+				OrganizationId: "org-1",
+			},
+		},
+	}
+	gateway := newThreadsGateway(client)
+	ctx := identity.WithIdentity(context.Background(), identity.ResolvedIdentity{
+		IdentityID:   "agent-1",
+		IdentityType: identity.IdentityTypeAgent,
+	})
+
+	gotCtx, err := gateway.withOrganizationContext(ctx)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if client.getAgentCalls != 1 {
+		t.Fatalf("expected agent lookup once, got %d", client.getAgentCalls)
+	}
+	if client.getAgentReq == nil || client.getAgentReq.GetId() != "agent-1" {
+		t.Fatalf("expected agent id to be forwarded")
+	}
+	md, ok := metadata.FromOutgoingContext(gotCtx)
+	if !ok {
+		t.Fatalf("expected outgoing metadata")
+	}
+	values := md.Get(identity.MetadataKeyOrganizationID)
+	if len(values) != 1 || values[0] != "org-1" {
+		t.Fatalf("expected organization metadata to be injected, got %#v", values)
+	}
+}
+
+func TestWithOrganizationContextAgentMissingOrg(t *testing.T) {
+	client := &fakeAgentsClient{
+		getAgentResp: &agentsv1.GetAgentResponse{
+			Agent: &agentsv1.Agent{},
+		},
+	}
+	gateway := newThreadsGateway(client)
+	ctx := identity.WithIdentity(context.Background(), identity.ResolvedIdentity{
+		IdentityID:   "agent-1",
+		IdentityType: identity.IdentityTypeAgent,
+	})
+
+	_, err := gateway.withOrganizationContext(ctx)
+	if err == nil {
+		t.Fatalf("expected error")
+	}
+	if status.Code(err) != codes.Internal {
+		t.Fatalf("expected internal error, got %v", status.Code(err))
+	}
+	if client.getAgentCalls != 1 {
+		t.Fatalf("expected agent lookup once, got %d", client.getAgentCalls)
+	}
+}


### PR DESCRIPTION
## Summary
- inject x-organization-id for agent-scoped threads requests
- handle agent lookup and org validation in threads gateway
- copy buf.lock before buf generate in Dockerfile

## Testing
- buf generate ../api --include-imports --path ../api/proto/agynio/api/agents/v1 --path ../api/proto/agynio/api/apps/v1 --path ../api/proto/agynio/api/threads/v1 --path ../api/proto/agynio/api/chat/v1 --path ../api/proto/agynio/api/notifications/v1 --path ../api/proto/agynio/api/files/v1 --path ../api/proto/agynio/api/agent_state/v1 --path ../api/proto/agynio/api/token_counting/v1 --path ../api/proto/agynio/api/metering/v1 --path ../api/proto/agynio/api/llm/v1 --path ../api/proto/agynio/api/secrets/v1 --path ../api/proto/agynio/api/identity/v1 --path ../api/proto/agynio/api/tracing/v1 --path ../api/proto/agynio/api/users/v1 --path ../api/proto/agynio/api/organizations/v1 --path ../api/proto/agynio/api/runners/v1 --path ../api/proto/agynio/api/expose/v1 --path ../api/proto/agynio/api/ziti_management/v1 --path ../api/proto/agynio/api/gateway/v1
- go vet ./...
- go test ./...

Refs #14