### PR TITLE
feat(apps): forward install audit RPCs

### DIFF
--- a/buf.lock
+++ b/buf.lock
@@ -2,8 +2,8 @@
 version: v2
 deps:
   - name: buf.build/agynio/api
-    commit: b67ca28ce2c94ca1a95f27e18051641b
-    digest: b5:860be1241b618cf64fcae9256df1278fe1cdf6e8ac13989eb34557d485d0f0a909f4daa94bac1a3ca386f520eb3097527c7ba2c78abc67bcd7cf8f44702ead40
+    commit: bbd8e6ab60974e9eb324ba9c4eeda240
+    digest: b5:cc2e55d819491abdd339a301e556ada1430b27257951e08ae66c24ac45b7b2f191f0d6fd007d6a0073bf91180436dfbc2e657fbafc4888bc2c7c07543b1e5510
   - name: buf.build/opentelemetry/opentelemetry
     commit: 5f2c7d4f740541589805e0816dad4bb0
     digest: b5:935626c896cfe0f5efda467869c65df49843190c1d16ad24957d62ae840aef5f5da2474ec5c766e730b2727c6a24b39b5a2a073da70cf3f2611ce7d3934def86

--- a/internal/gateway/appproxy_test.go
+++ b/internal/gateway/appproxy_test.go
@@ -74,6 +74,10 @@ func (f *fakeAppsClient) GetInstallationBySlug(ctx context.Context, req *appsv1.
 	return nil, status.Error(codes.Unimplemented, "not implemented")
 }
 
+func (f *fakeAppsClient) GetInstallationByIdentityId(ctx context.Context, req *appsv1.GetInstallationByIdentityIdRequest, opts ...grpc.CallOption) (*appsv1.GetInstallationByIdentityIdResponse, error) {
+	return nil, status.Error(codes.Unimplemented, "not implemented")
+}
+
 func (f *fakeAppsClient) ListInstallations(ctx context.Context, req *appsv1.ListInstallationsRequest, opts ...grpc.CallOption) (*appsv1.ListInstallationsResponse, error) {
 	return nil, status.Error(codes.Unimplemented, "not implemented")
 }
@@ -87,6 +91,18 @@ func (f *fakeAppsClient) UninstallApp(ctx context.Context, req *appsv1.Uninstall
 }
 
 func (f *fakeAppsClient) GetInstallationConfiguration(ctx context.Context, req *appsv1.GetInstallationConfigurationRequest, opts ...grpc.CallOption) (*appsv1.GetInstallationConfigurationResponse, error) {
+	return nil, status.Error(codes.Unimplemented, "not implemented")
+}
+
+func (f *fakeAppsClient) ReportInstallationStatus(ctx context.Context, req *appsv1.ReportInstallationStatusRequest, opts ...grpc.CallOption) (*appsv1.ReportInstallationStatusResponse, error) {
+	return nil, status.Error(codes.Unimplemented, "not implemented")
+}
+
+func (f *fakeAppsClient) AppendInstallationAuditLogEntry(ctx context.Context, req *appsv1.AppendInstallationAuditLogEntryRequest, opts ...grpc.CallOption) (*appsv1.AppendInstallationAuditLogEntryResponse, error) {
+	return nil, status.Error(codes.Unimplemented, "not implemented")
+}
+
+func (f *fakeAppsClient) ListInstallationAuditLogEntries(ctx context.Context, req *appsv1.ListInstallationAuditLogEntriesRequest, opts ...grpc.CallOption) (*appsv1.ListInstallationAuditLogEntriesResponse, error) {
 	return nil, status.Error(codes.Unimplemented, "not implemented")
 }
 

--- a/internal/gateway/apps.go
+++ b/internal/gateway/apps.go
@@ -118,3 +118,27 @@ func (g *Gateway) UninstallApp(ctx context.Context, req *connect.Request[appsv1.
 	}
 	return connect.NewResponse(resp), nil
 }
+
+func (g *Gateway) ReportInstallationStatus(ctx context.Context, req *connect.Request[appsv1.ReportInstallationStatusRequest]) (*connect.Response[appsv1.ReportInstallationStatusResponse], error) {
+	resp, err := g.apps.ReportInstallationStatus(ctx, req.Msg)
+	if err != nil {
+		return nil, toConnectError(err)
+	}
+	return connect.NewResponse(resp), nil
+}
+
+func (g *Gateway) AppendInstallationAuditLogEntry(ctx context.Context, req *connect.Request[appsv1.AppendInstallationAuditLogEntryRequest]) (*connect.Response[appsv1.AppendInstallationAuditLogEntryResponse], error) {
+	resp, err := g.apps.AppendInstallationAuditLogEntry(ctx, req.Msg)
+	if err != nil {
+		return nil, toConnectError(err)
+	}
+	return connect.NewResponse(resp), nil
+}
+
+func (g *Gateway) ListInstallationAuditLogEntries(ctx context.Context, req *connect.Request[appsv1.ListInstallationAuditLogEntriesRequest]) (*connect.Response[appsv1.ListInstallationAuditLogEntriesResponse], error) {
+	resp, err := g.apps.ListInstallationAuditLogEntries(ctx, req.Msg)
+	if err != nil {
+		return nil, toConnectError(err)
+	}
+	return connect.NewResponse(resp), nil
+}


### PR DESCRIPTION
## Summary
- forward installation status + audit log RPCs through the gateway
- extend fake apps client to cover new methods

## Testing
- go vet ./...
- go test ./...

## Issue
- #137