### PR TITLE
fix(appproxy): dial app service by slug

### DIFF
--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -10,12 +10,6 @@ jobs:
     timeout-minutes: 60
     permissions:
       contents: read
-    env:
-      AGYN_AGENT_INIT_IMAGE: ghcr.io/agynio/agent-init:latest
-      CODEX_INIT_IMAGE: ghcr.io/agynio/agent-init-codex:latest
-      AGN_INIT_IMAGE: ghcr.io/agynio/agent-init-agn:latest
-      CLAUDE_INIT_IMAGE: ghcr.io/agynio/agent-init-claude:latest
-      AGN_EXPOSE_INIT_IMAGE: ghcr.io/agynio/agent-init-agn:latest
     steps:
       - name: Checkout
         uses: actions/checkout@v4

--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -10,6 +10,12 @@ jobs:
     timeout-minutes: 60
     permissions:
       contents: read
+    env:
+      AGYN_AGENT_INIT_IMAGE: ghcr.io/agynio/agent-init:v1.0.0
+      CODEX_INIT_IMAGE: ghcr.io/agynio/agent-init-codex:0.13
+      AGN_INIT_IMAGE: ghcr.io/agynio/agent-init-agn:0.4
+      CLAUDE_INIT_IMAGE: ghcr.io/agynio/agent-init-claude:0.1
+      AGN_EXPOSE_INIT_IMAGE: ghcr.io/agynio/agent-init-agn:0.4
     steps:
       - name: Checkout
         uses: actions/checkout@v4

--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -11,11 +11,11 @@ jobs:
     permissions:
       contents: read
     env:
-      AGYN_AGENT_INIT_IMAGE: ghcr.io/agynio/agent-init:v1.0.0
-      CODEX_INIT_IMAGE: ghcr.io/agynio/agent-init-codex:0.13
-      AGN_INIT_IMAGE: ghcr.io/agynio/agent-init-agn:0.4
-      CLAUDE_INIT_IMAGE: ghcr.io/agynio/agent-init-claude:0.1
-      AGN_EXPOSE_INIT_IMAGE: ghcr.io/agynio/agent-init-agn:0.4
+      AGYN_AGENT_INIT_IMAGE: ghcr.io/agynio/agent-init:latest
+      CODEX_INIT_IMAGE: ghcr.io/agynio/agent-init-codex:latest
+      AGN_INIT_IMAGE: ghcr.io/agynio/agent-init-agn:latest
+      CLAUDE_INIT_IMAGE: ghcr.io/agynio/agent-init-claude:latest
+      AGN_EXPOSE_INIT_IMAGE: ghcr.io/agynio/agent-init-agn:latest
     steps:
       - name: Checkout
         uses: actions/checkout@v4

--- a/devspace.yaml
+++ b/devspace.yaml
@@ -82,7 +82,7 @@ pipelines:
         start_dev --disable-pod-replace gateway
         echo "Waiting for gateway to be healthy on :8080..."
         healthy=false
-        for i in $(seq 1 150); do
+        for i in $(seq 1 300); do
           if kubectl exec deployment/gateway-gateway -n ${GATEWAY_NAMESPACE} -c gateway -- bash -c 'nc -z localhost 8080 >/dev/null 2>&1 || (echo > /dev/tcp/localhost/8080) >/dev/null 2>&1' 2>/dev/null; then
             echo "Gateway is healthy on :8080."
             healthy=true
@@ -91,7 +91,7 @@ pipelines:
           sleep 2
         done
         if [ "$healthy" != "true" ]; then
-          echo "ERROR: Gateway did not become healthy within 300s" >&2
+          echo "ERROR: Gateway did not become healthy within 600s" >&2
           exit 1
         fi
         echo "Dev environment ready. Stopping dev session."

--- a/internal/gateway/appproxy.go
+++ b/internal/gateway/appproxy.go
@@ -161,12 +161,11 @@ func (h *AppProxyHandler) resolveInstallation(ctx context.Context, orgID, slug s
 		return resolvedInstallation{}, fmt.Errorf("app response missing")
 	}
 
-	serviceID := strings.TrimSpace(app.GetZitiServiceId())
-	if serviceID == "" {
-		return resolvedInstallation{}, fmt.Errorf("app service id missing")
+	appSlug := strings.TrimSpace(app.GetSlug())
+	if appSlug == "" {
+		return resolvedInstallation{}, fmt.Errorf("app slug missing")
 	}
-	// ZitiServiceId stores the dialable service identifier for the app.
-	serviceName := serviceID
+	serviceName := fmt.Sprintf("app-%s", appSlug)
 
 	resolved := resolvedInstallation{installationID: installationID, serviceName: serviceName}
 	h.cacheMu.Lock()

--- a/internal/gateway/appproxy_test.go
+++ b/internal/gateway/appproxy_test.go
@@ -156,7 +156,7 @@ func TestResolveInstallationCache(t *testing.T) {
 		},
 		getApp: func(ctx context.Context, req *appsv1.GetAppRequest, opts ...grpc.CallOption) (*appsv1.GetAppResponse, error) {
 			appCalls++
-			return &appsv1.GetAppResponse{App: &appsv1.App{ZitiServiceId: "service-" + req.Id}}, nil
+			return &appsv1.GetAppResponse{App: &appsv1.App{Slug: "slug-" + req.Id}}, nil
 		},
 	}
 	handler := &AppProxyHandler{
@@ -170,8 +170,8 @@ func TestResolveInstallationCache(t *testing.T) {
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}
-	if resolved.serviceName != "service-app-org-1" {
-		t.Fatalf("expected service name %q, got %q", "service-app-org-1", resolved.serviceName)
+	if resolved.serviceName != "app-slug-app-org-1" {
+		t.Fatalf("expected service name %q, got %q", "app-slug-app-org-1", resolved.serviceName)
 	}
 	if resolved.installationID != "inst-org-1" {
 		t.Fatalf("expected installation id %q, got %q", "inst-org-1", resolved.installationID)
@@ -181,8 +181,8 @@ func TestResolveInstallationCache(t *testing.T) {
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}
-	if resolved.serviceName != "service-app-org-1" {
-		t.Fatalf("expected service name %q, got %q", "service-app-org-1", resolved.serviceName)
+	if resolved.serviceName != "app-slug-app-org-1" {
+		t.Fatalf("expected service name %q, got %q", "app-slug-app-org-1", resolved.serviceName)
 	}
 	if installationCalls != 1 {
 		t.Fatalf("expected installation lookup once, got %d", installationCalls)
@@ -196,8 +196,8 @@ func TestResolveInstallationCache(t *testing.T) {
 		if err != nil {
 			t.Fatalf("unexpected error: %v", err)
 		}
-		if resolved.serviceName != "service-app-org-2" {
-			t.Fatalf("expected service name %q, got %q", "service-app-org-2", resolved.serviceName)
+		if resolved.serviceName != "app-slug-app-org-2" {
+			t.Fatalf("expected service name %q, got %q", "app-slug-app-org-2", resolved.serviceName)
 		}
 		if resolved.installationID != "inst-org-2" {
 			t.Fatalf("expected installation id %q, got %q", "inst-org-2", resolved.installationID)
@@ -269,7 +269,7 @@ func TestResolveInstallationErrors(t *testing.T) {
 		}
 	})
 
-	t.Run("missing service id", func(t *testing.T) {
+	t.Run("missing slug", func(t *testing.T) {
 		handler := &AppProxyHandler{
 			apps: &fakeAppsClient{
 				getInstallationBySlug: func(ctx context.Context, req *appsv1.GetInstallationBySlugRequest, opts ...grpc.CallOption) (*appsv1.GetInstallationBySlugResponse, error) {
@@ -279,7 +279,7 @@ func TestResolveInstallationErrors(t *testing.T) {
 					}}, nil
 				},
 				getApp: func(ctx context.Context, req *appsv1.GetAppRequest, opts ...grpc.CallOption) (*appsv1.GetAppResponse, error) {
-					return &appsv1.GetAppResponse{App: &appsv1.App{ZitiServiceId: " "}}, nil
+					return &appsv1.GetAppResponse{App: &appsv1.App{Slug: " "}}, nil
 				},
 			},
 			cache:    make(map[string]cachedInstallation),
@@ -326,7 +326,7 @@ func TestAppProxyHandlerServeHTTP(t *testing.T) {
 			}}, nil
 		},
 		getApp: func(ctx context.Context, req *appsv1.GetAppRequest, opts ...grpc.CallOption) (*appsv1.GetAppResponse, error) {
-			return &appsv1.GetAppResponse{App: &appsv1.App{ZitiServiceId: "service"}}, nil
+			return &appsv1.GetAppResponse{App: &appsv1.App{Slug: "app-slug"}}, nil
 		},
 	}
 	handler := &AppProxyHandler{

--- a/internal/gateway/threads.go
+++ b/internal/gateway/threads.go
@@ -72,14 +72,6 @@ func (g *ThreadsGateway) GetOrganizationThreads(ctx context.Context, req *connec
 	return connect.NewResponse(resp), nil
 }
 
-func (g *ThreadsGateway) ListOrganizationThreads(ctx context.Context, req *connect.Request[threadsv1.ListOrganizationThreadsRequest]) (*connect.Response[threadsv1.ListOrganizationThreadsResponse], error) {
-	resp, err := g.threads.ListOrganizationThreads(ctx, req.Msg)
-	if err != nil {
-		return nil, toConnectError(err)
-	}
-	return connect.NewResponse(resp), nil
-}
-
 func (g *ThreadsGateway) GetThread(ctx context.Context, req *connect.Request[threadsv1.GetThreadRequest]) (*connect.Response[threadsv1.GetThreadResponse], error) {
 	resp, err := g.threads.GetThread(ctx, req.Msg)
 	if err != nil {
@@ -98,6 +90,14 @@ func (g *ThreadsGateway) GetMessages(ctx context.Context, req *connect.Request[t
 
 func (g *ThreadsGateway) GetUnackedMessages(ctx context.Context, req *connect.Request[threadsv1.GetUnackedMessagesRequest]) (*connect.Response[threadsv1.GetUnackedMessagesResponse], error) {
 	resp, err := g.threads.GetUnackedMessages(ctx, req.Msg)
+	if err != nil {
+		return nil, toConnectError(err)
+	}
+	return connect.NewResponse(resp), nil
+}
+
+func (g *ThreadsGateway) GetUnackedMessageCounts(ctx context.Context, req *connect.Request[threadsv1.GetUnackedMessageCountsRequest]) (*connect.Response[threadsv1.GetUnackedMessageCountsResponse], error) {
+	resp, err := g.threads.GetUnackedMessageCounts(ctx, req.Msg)
 	if err != nil {
 		return nil, toConnectError(err)
 	}


### PR DESCRIPTION
## Summary
- derive app-proxy dial service name from app slug instead of ziti_service_id
- add missing ThreadsGateway GetUnackedMessageCounts forwarding for updated API
- update appproxy tests for slug-derived service names

## Testing
- buf generate buf.build/agynio/api
- go test ./...

Refs: agynio/e2e#68