### PR TITLE
fix(app-proxy): derive org and strip headers

### DIFF
--- a/cmd/gateway/main.go
+++ b/cmd/gateway/main.go
@@ -263,7 +263,7 @@ func main() {
 			}
 		}()
 
-		appProxyHandler := http.Handler(gateway.NewAppProxyHandler(appsClient, mgr, defaultAppProxyCacheTTL))
+		appProxyHandler := http.Handler(gateway.NewAppProxyHandler(appsClient, agentsClient, organizationsClient, mgr, defaultAppProxyCacheTTL))
 		if zitiResolver != nil || oidcResolver != nil || apiTokenResolver != nil || clusterAdminResolver != nil {
 			appProxyHandler = gateway.NewAuthMiddleware(zitiResolver, oidcResolver, apiTokenResolver, clusterAdminResolver)(appProxyHandler)
 		}

--- a/cmd/gateway/main.go
+++ b/cmd/gateway/main.go
@@ -263,7 +263,7 @@ func main() {
 			}
 		}()
 
-		appProxyHandler := http.Handler(gateway.NewAppProxyHandler(appsClient, agentsClient, organizationsClient, mgr, defaultAppProxyCacheTTL))
+		appProxyHandler := http.Handler(gateway.NewAppProxyHandler(appsClient, agentsClient, mgr, defaultAppProxyCacheTTL))
 		if zitiResolver != nil || oidcResolver != nil || apiTokenResolver != nil || clusterAdminResolver != nil {
 			appProxyHandler = gateway.NewAuthMiddleware(zitiResolver, oidcResolver, apiTokenResolver, clusterAdminResolver)(appProxyHandler)
 		}

--- a/internal/gateway/appproxy.go
+++ b/internal/gateway/appproxy.go
@@ -12,13 +12,19 @@ import (
 	"sync"
 	"time"
 
+	agentsv1 "github.com/agynio/gateway/gen/agynio/api/agents/v1"
 	appsv1 "github.com/agynio/gateway/gen/agynio/api/apps/v1"
+	organizationsv1 "github.com/agynio/gateway/gen/agynio/api/organizations/v1"
 	"github.com/agynio/gateway/internal/identity"
 	"github.com/openziti/sdk-golang/ziti"
+	"google.golang.org/grpc/codes"
+	"google.golang.org/grpc/status"
 )
 
 type AppProxyHandler struct {
 	apps                appsv1.AppsServiceClient
+	agents              agentsv1.AgentsServiceClient
+	organizations       organizationsv1.OrganizationsServiceClient
 	zitiContextProvider ZitiContextProvider
 	transport           *http.Transport
 	client              *http.Client
@@ -41,7 +47,13 @@ type ZitiContextProvider interface {
 	ZitiContext() ziti.Context
 }
 
-func NewAppProxyHandler(apps appsv1.AppsServiceClient, zitiContextProvider ZitiContextProvider, cacheTTL time.Duration) *AppProxyHandler {
+func NewAppProxyHandler(
+	apps appsv1.AppsServiceClient,
+	agents agentsv1.AgentsServiceClient,
+	organizations organizationsv1.OrganizationsServiceClient,
+	zitiContextProvider ZitiContextProvider,
+	cacheTTL time.Duration,
+) *AppProxyHandler {
 	if apps == nil {
 		panic("apps client is required")
 	}
@@ -54,6 +66,8 @@ func NewAppProxyHandler(apps appsv1.AppsServiceClient, zitiContextProvider ZitiC
 
 	handler := &AppProxyHandler{
 		apps:                apps,
+		agents:              agents,
+		organizations:       organizations,
 		zitiContextProvider: zitiContextProvider,
 		cache:               make(map[string]cachedInstallation),
 		cacheTTL:            cacheTTL,
@@ -66,6 +80,43 @@ func NewAppProxyHandler(apps appsv1.AppsServiceClient, zitiContextProvider ZitiC
 	return handler
 }
 
+func (h *AppProxyHandler) resolveOrganizationID(ctx context.Context, resolved identity.ResolvedIdentity) (string, error) {
+	switch resolved.IdentityType {
+	case identity.IdentityTypeAgent:
+		if h.agents == nil {
+			return "", status.Error(codes.Internal, "agent resolver not configured")
+		}
+		resp, err := h.agents.ResolveAgentIdentity(ctx, &agentsv1.ResolveAgentIdentityRequest{IdentityId: resolved.IdentityID})
+		if err != nil {
+			return "", err
+		}
+		orgID := strings.TrimSpace(resp.GetOrganizationId())
+		if orgID == "" {
+			return "", status.Error(codes.FailedPrecondition, "organization id missing")
+		}
+		return orgID, nil
+	case identity.IdentityTypeUser:
+		if h.organizations == nil {
+			return "", status.Error(codes.Internal, "organizations resolver not configured")
+		}
+		resp, err := h.organizations.ListMyMemberships(ctx, &organizationsv1.ListMyMembershipsRequest{})
+		if err != nil {
+			return "", err
+		}
+		memberships := resp.GetMemberships()
+		if len(memberships) == 0 {
+			return "", status.Error(codes.NotFound, "no organization memberships")
+		}
+		orgID := strings.TrimSpace(memberships[0].GetOrganizationId())
+		if orgID == "" {
+			return "", status.Error(codes.FailedPrecondition, "organization id missing")
+		}
+		return orgID, nil
+	default:
+		return "", status.Error(codes.Unimplemented, "organization resolution not supported for identity type")
+	}
+}
+
 func (h *AppProxyHandler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 	slug, method, err := parseAppProxyPath(r.URL.Path)
 	if err != nil {
@@ -73,13 +124,20 @@ func (h *AppProxyHandler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	orgID := strings.TrimSpace(r.Header.Get(identity.MetadataKeyOrganizationID))
-	if orgID == "" {
-		writeProblem(w, http.StatusBadRequest, "missing x-organization-id header")
+	ctx := r.Context()
+	resolvedIdentity, ok := identity.IdentityFromContext(ctx)
+	if !ok {
+		writeProblem(w, http.StatusUnauthorized, "identity not available")
 		return
 	}
 
-	resolved, err := h.resolveInstallation(r.Context(), orgID, slug)
+	orgID, err := h.resolveOrganizationID(ctx, resolvedIdentity)
+	if err != nil {
+		writeProblem(w, httpStatusFromError(err), err.Error())
+		return
+	}
+
+	resolved, err := h.resolveInstallation(ctx, orgID, slug)
 	if err != nil {
 		writeProblem(w, httpStatusFromError(err), err.Error())
 		return
@@ -100,12 +158,10 @@ func (h *AppProxyHandler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 	proxyReq.Header = r.Header.Clone()
 	proxyReq.ContentLength = r.ContentLength
 	proxyReq.Host = resolved.serviceName
+	stripInternalHeaders(proxyReq.Header)
+	proxyReq.Header.Set(identity.MetadataKeyIdentityID, resolvedIdentity.IdentityID)
+	proxyReq.Header.Set(identity.MetadataKeyIdentityType, string(resolvedIdentity.IdentityType))
 	proxyReq.Header.Set(identity.MetadataKeyAppInstallationID, resolved.installationID)
-
-	if ident, ok := identity.IdentityFromContext(r.Context()); ok {
-		proxyReq.Header.Set(identity.MetadataKeyIdentityID, ident.IdentityID)
-		proxyReq.Header.Set(identity.MetadataKeyIdentityType, string(ident.IdentityType))
-	}
 
 	resp, err := h.client.Do(proxyReq)
 	if err != nil {
@@ -211,4 +267,15 @@ func (h *AppProxyHandler) dialContext(ctx context.Context, network, addr string)
 	}
 
 	return zitiContext.Dial(serviceName)
+}
+
+func stripInternalHeaders(header http.Header) {
+	if header == nil {
+		return
+	}
+	header.Del(identity.MetadataKeyOrganizationID)
+	header.Del(identity.MetadataKeyIdentityID)
+	header.Del(identity.MetadataKeyIdentityType)
+	header.Del(identity.MetadataKeyWorkloadID)
+	header.Del(identity.MetadataKeyAppInstallationID)
 }

--- a/internal/gateway/appproxy.go
+++ b/internal/gateway/appproxy.go
@@ -14,7 +14,6 @@ import (
 
 	agentsv1 "github.com/agynio/gateway/gen/agynio/api/agents/v1"
 	appsv1 "github.com/agynio/gateway/gen/agynio/api/apps/v1"
-	organizationsv1 "github.com/agynio/gateway/gen/agynio/api/organizations/v1"
 	"github.com/agynio/gateway/internal/identity"
 	"github.com/openziti/sdk-golang/ziti"
 	"google.golang.org/grpc/codes"
@@ -24,7 +23,6 @@ import (
 type AppProxyHandler struct {
 	apps                appsv1.AppsServiceClient
 	agents              agentsv1.AgentsServiceClient
-	organizations       organizationsv1.OrganizationsServiceClient
 	zitiContextProvider ZitiContextProvider
 	transport           *http.Transport
 	client              *http.Client
@@ -50,7 +48,6 @@ type ZitiContextProvider interface {
 func NewAppProxyHandler(
 	apps appsv1.AppsServiceClient,
 	agents agentsv1.AgentsServiceClient,
-	organizations organizationsv1.OrganizationsServiceClient,
 	zitiContextProvider ZitiContextProvider,
 	cacheTTL time.Duration,
 ) *AppProxyHandler {
@@ -67,7 +64,6 @@ func NewAppProxyHandler(
 	handler := &AppProxyHandler{
 		apps:                apps,
 		agents:              agents,
-		organizations:       organizations,
 		zitiContextProvider: zitiContextProvider,
 		cache:               make(map[string]cachedInstallation),
 		cacheTTL:            cacheTTL,
@@ -96,22 +92,7 @@ func (h *AppProxyHandler) resolveOrganizationID(ctx context.Context, resolved id
 		}
 		return orgID, nil
 	case identity.IdentityTypeUser:
-		if h.organizations == nil {
-			return "", status.Error(codes.Internal, "organizations resolver not configured")
-		}
-		resp, err := h.organizations.ListMyMemberships(ctx, &organizationsv1.ListMyMembershipsRequest{})
-		if err != nil {
-			return "", err
-		}
-		memberships := resp.GetMemberships()
-		if len(memberships) == 0 {
-			return "", status.Error(codes.NotFound, "no organization memberships")
-		}
-		orgID := strings.TrimSpace(memberships[0].GetOrganizationId())
-		if orgID == "" {
-			return "", status.Error(codes.FailedPrecondition, "organization id missing")
-		}
-		return orgID, nil
+		return "", status.Error(codes.FailedPrecondition, "organization id is required for user identity")
 	default:
 		return "", status.Error(codes.Unimplemented, "organization resolution not supported for identity type")
 	}

--- a/internal/gateway/appproxy_test.go
+++ b/internal/gateway/appproxy_test.go
@@ -8,7 +8,9 @@ import (
 	"testing"
 	"time"
 
+	agentsv1 "github.com/agynio/gateway/gen/agynio/api/agents/v1"
 	appsv1 "github.com/agynio/gateway/gen/agynio/api/apps/v1"
+	organizationsv1 "github.com/agynio/gateway/gen/agynio/api/organizations/v1"
 	"github.com/agynio/gateway/internal/identity"
 	"google.golang.org/grpc"
 	"google.golang.org/grpc/codes"
@@ -103,6 +105,252 @@ func (f *fakeAppsClient) AppendInstallationAuditLogEntry(ctx context.Context, re
 }
 
 func (f *fakeAppsClient) ListInstallationAuditLogEntries(ctx context.Context, req *appsv1.ListInstallationAuditLogEntriesRequest, opts ...grpc.CallOption) (*appsv1.ListInstallationAuditLogEntriesResponse, error) {
+	return nil, status.Error(codes.Unimplemented, "not implemented")
+}
+
+type fakeAgentsClient struct {
+	resolveAgentIdentity func(ctx context.Context, req *agentsv1.ResolveAgentIdentityRequest, opts ...grpc.CallOption) (*agentsv1.ResolveAgentIdentityResponse, error)
+}
+
+func (f *fakeAgentsClient) CreateAgent(ctx context.Context, req *agentsv1.CreateAgentRequest, opts ...grpc.CallOption) (*agentsv1.CreateAgentResponse, error) {
+	return nil, status.Error(codes.Unimplemented, "not implemented")
+}
+
+func (f *fakeAgentsClient) GetAgent(ctx context.Context, req *agentsv1.GetAgentRequest, opts ...grpc.CallOption) (*agentsv1.GetAgentResponse, error) {
+	return nil, status.Error(codes.Unimplemented, "not implemented")
+}
+
+func (f *fakeAgentsClient) ResolveAgentIdentity(ctx context.Context, req *agentsv1.ResolveAgentIdentityRequest, opts ...grpc.CallOption) (*agentsv1.ResolveAgentIdentityResponse, error) {
+	if f.resolveAgentIdentity != nil {
+		return f.resolveAgentIdentity(ctx, req, opts...)
+	}
+	return nil, status.Error(codes.Unimplemented, "not implemented")
+}
+
+func (f *fakeAgentsClient) UpdateAgent(ctx context.Context, req *agentsv1.UpdateAgentRequest, opts ...grpc.CallOption) (*agentsv1.UpdateAgentResponse, error) {
+	return nil, status.Error(codes.Unimplemented, "not implemented")
+}
+
+func (f *fakeAgentsClient) DeleteAgent(ctx context.Context, req *agentsv1.DeleteAgentRequest, opts ...grpc.CallOption) (*agentsv1.DeleteAgentResponse, error) {
+	return nil, status.Error(codes.Unimplemented, "not implemented")
+}
+
+func (f *fakeAgentsClient) ListAgents(ctx context.Context, req *agentsv1.ListAgentsRequest, opts ...grpc.CallOption) (*agentsv1.ListAgentsResponse, error) {
+	return nil, status.Error(codes.Unimplemented, "not implemented")
+}
+
+func (f *fakeAgentsClient) CreateVolume(ctx context.Context, req *agentsv1.CreateVolumeRequest, opts ...grpc.CallOption) (*agentsv1.CreateVolumeResponse, error) {
+	return nil, status.Error(codes.Unimplemented, "not implemented")
+}
+
+func (f *fakeAgentsClient) GetVolume(ctx context.Context, req *agentsv1.GetVolumeRequest, opts ...grpc.CallOption) (*agentsv1.GetVolumeResponse, error) {
+	return nil, status.Error(codes.Unimplemented, "not implemented")
+}
+
+func (f *fakeAgentsClient) UpdateVolume(ctx context.Context, req *agentsv1.UpdateVolumeRequest, opts ...grpc.CallOption) (*agentsv1.UpdateVolumeResponse, error) {
+	return nil, status.Error(codes.Unimplemented, "not implemented")
+}
+
+func (f *fakeAgentsClient) DeleteVolume(ctx context.Context, req *agentsv1.DeleteVolumeRequest, opts ...grpc.CallOption) (*agentsv1.DeleteVolumeResponse, error) {
+	return nil, status.Error(codes.Unimplemented, "not implemented")
+}
+
+func (f *fakeAgentsClient) ListVolumes(ctx context.Context, req *agentsv1.ListVolumesRequest, opts ...grpc.CallOption) (*agentsv1.ListVolumesResponse, error) {
+	return nil, status.Error(codes.Unimplemented, "not implemented")
+}
+
+func (f *fakeAgentsClient) CreateVolumeAttachment(ctx context.Context, req *agentsv1.CreateVolumeAttachmentRequest, opts ...grpc.CallOption) (*agentsv1.CreateVolumeAttachmentResponse, error) {
+	return nil, status.Error(codes.Unimplemented, "not implemented")
+}
+
+func (f *fakeAgentsClient) GetVolumeAttachment(ctx context.Context, req *agentsv1.GetVolumeAttachmentRequest, opts ...grpc.CallOption) (*agentsv1.GetVolumeAttachmentResponse, error) {
+	return nil, status.Error(codes.Unimplemented, "not implemented")
+}
+
+func (f *fakeAgentsClient) DeleteVolumeAttachment(ctx context.Context, req *agentsv1.DeleteVolumeAttachmentRequest, opts ...grpc.CallOption) (*agentsv1.DeleteVolumeAttachmentResponse, error) {
+	return nil, status.Error(codes.Unimplemented, "not implemented")
+}
+
+func (f *fakeAgentsClient) ListVolumeAttachments(ctx context.Context, req *agentsv1.ListVolumeAttachmentsRequest, opts ...grpc.CallOption) (*agentsv1.ListVolumeAttachmentsResponse, error) {
+	return nil, status.Error(codes.Unimplemented, "not implemented")
+}
+
+func (f *fakeAgentsClient) CreateMcp(ctx context.Context, req *agentsv1.CreateMcpRequest, opts ...grpc.CallOption) (*agentsv1.CreateMcpResponse, error) {
+	return nil, status.Error(codes.Unimplemented, "not implemented")
+}
+
+func (f *fakeAgentsClient) GetMcp(ctx context.Context, req *agentsv1.GetMcpRequest, opts ...grpc.CallOption) (*agentsv1.GetMcpResponse, error) {
+	return nil, status.Error(codes.Unimplemented, "not implemented")
+}
+
+func (f *fakeAgentsClient) UpdateMcp(ctx context.Context, req *agentsv1.UpdateMcpRequest, opts ...grpc.CallOption) (*agentsv1.UpdateMcpResponse, error) {
+	return nil, status.Error(codes.Unimplemented, "not implemented")
+}
+
+func (f *fakeAgentsClient) DeleteMcp(ctx context.Context, req *agentsv1.DeleteMcpRequest, opts ...grpc.CallOption) (*agentsv1.DeleteMcpResponse, error) {
+	return nil, status.Error(codes.Unimplemented, "not implemented")
+}
+
+func (f *fakeAgentsClient) ListMcps(ctx context.Context, req *agentsv1.ListMcpsRequest, opts ...grpc.CallOption) (*agentsv1.ListMcpsResponse, error) {
+	return nil, status.Error(codes.Unimplemented, "not implemented")
+}
+
+func (f *fakeAgentsClient) CreateSkill(ctx context.Context, req *agentsv1.CreateSkillRequest, opts ...grpc.CallOption) (*agentsv1.CreateSkillResponse, error) {
+	return nil, status.Error(codes.Unimplemented, "not implemented")
+}
+
+func (f *fakeAgentsClient) GetSkill(ctx context.Context, req *agentsv1.GetSkillRequest, opts ...grpc.CallOption) (*agentsv1.GetSkillResponse, error) {
+	return nil, status.Error(codes.Unimplemented, "not implemented")
+}
+
+func (f *fakeAgentsClient) UpdateSkill(ctx context.Context, req *agentsv1.UpdateSkillRequest, opts ...grpc.CallOption) (*agentsv1.UpdateSkillResponse, error) {
+	return nil, status.Error(codes.Unimplemented, "not implemented")
+}
+
+func (f *fakeAgentsClient) DeleteSkill(ctx context.Context, req *agentsv1.DeleteSkillRequest, opts ...grpc.CallOption) (*agentsv1.DeleteSkillResponse, error) {
+	return nil, status.Error(codes.Unimplemented, "not implemented")
+}
+
+func (f *fakeAgentsClient) ListSkills(ctx context.Context, req *agentsv1.ListSkillsRequest, opts ...grpc.CallOption) (*agentsv1.ListSkillsResponse, error) {
+	return nil, status.Error(codes.Unimplemented, "not implemented")
+}
+
+func (f *fakeAgentsClient) CreateHook(ctx context.Context, req *agentsv1.CreateHookRequest, opts ...grpc.CallOption) (*agentsv1.CreateHookResponse, error) {
+	return nil, status.Error(codes.Unimplemented, "not implemented")
+}
+
+func (f *fakeAgentsClient) GetHook(ctx context.Context, req *agentsv1.GetHookRequest, opts ...grpc.CallOption) (*agentsv1.GetHookResponse, error) {
+	return nil, status.Error(codes.Unimplemented, "not implemented")
+}
+
+func (f *fakeAgentsClient) UpdateHook(ctx context.Context, req *agentsv1.UpdateHookRequest, opts ...grpc.CallOption) (*agentsv1.UpdateHookResponse, error) {
+	return nil, status.Error(codes.Unimplemented, "not implemented")
+}
+
+func (f *fakeAgentsClient) DeleteHook(ctx context.Context, req *agentsv1.DeleteHookRequest, opts ...grpc.CallOption) (*agentsv1.DeleteHookResponse, error) {
+	return nil, status.Error(codes.Unimplemented, "not implemented")
+}
+
+func (f *fakeAgentsClient) ListHooks(ctx context.Context, req *agentsv1.ListHooksRequest, opts ...grpc.CallOption) (*agentsv1.ListHooksResponse, error) {
+	return nil, status.Error(codes.Unimplemented, "not implemented")
+}
+
+func (f *fakeAgentsClient) CreateEnv(ctx context.Context, req *agentsv1.CreateEnvRequest, opts ...grpc.CallOption) (*agentsv1.CreateEnvResponse, error) {
+	return nil, status.Error(codes.Unimplemented, "not implemented")
+}
+
+func (f *fakeAgentsClient) GetEnv(ctx context.Context, req *agentsv1.GetEnvRequest, opts ...grpc.CallOption) (*agentsv1.GetEnvResponse, error) {
+	return nil, status.Error(codes.Unimplemented, "not implemented")
+}
+
+func (f *fakeAgentsClient) UpdateEnv(ctx context.Context, req *agentsv1.UpdateEnvRequest, opts ...grpc.CallOption) (*agentsv1.UpdateEnvResponse, error) {
+	return nil, status.Error(codes.Unimplemented, "not implemented")
+}
+
+func (f *fakeAgentsClient) DeleteEnv(ctx context.Context, req *agentsv1.DeleteEnvRequest, opts ...grpc.CallOption) (*agentsv1.DeleteEnvResponse, error) {
+	return nil, status.Error(codes.Unimplemented, "not implemented")
+}
+
+func (f *fakeAgentsClient) ListEnvs(ctx context.Context, req *agentsv1.ListEnvsRequest, opts ...grpc.CallOption) (*agentsv1.ListEnvsResponse, error) {
+	return nil, status.Error(codes.Unimplemented, "not implemented")
+}
+
+func (f *fakeAgentsClient) CreateInitScript(ctx context.Context, req *agentsv1.CreateInitScriptRequest, opts ...grpc.CallOption) (*agentsv1.CreateInitScriptResponse, error) {
+	return nil, status.Error(codes.Unimplemented, "not implemented")
+}
+
+func (f *fakeAgentsClient) GetInitScript(ctx context.Context, req *agentsv1.GetInitScriptRequest, opts ...grpc.CallOption) (*agentsv1.GetInitScriptResponse, error) {
+	return nil, status.Error(codes.Unimplemented, "not implemented")
+}
+
+func (f *fakeAgentsClient) UpdateInitScript(ctx context.Context, req *agentsv1.UpdateInitScriptRequest, opts ...grpc.CallOption) (*agentsv1.UpdateInitScriptResponse, error) {
+	return nil, status.Error(codes.Unimplemented, "not implemented")
+}
+
+func (f *fakeAgentsClient) DeleteInitScript(ctx context.Context, req *agentsv1.DeleteInitScriptRequest, opts ...grpc.CallOption) (*agentsv1.DeleteInitScriptResponse, error) {
+	return nil, status.Error(codes.Unimplemented, "not implemented")
+}
+
+func (f *fakeAgentsClient) ListInitScripts(ctx context.Context, req *agentsv1.ListInitScriptsRequest, opts ...grpc.CallOption) (*agentsv1.ListInitScriptsResponse, error) {
+	return nil, status.Error(codes.Unimplemented, "not implemented")
+}
+
+func (f *fakeAgentsClient) CreateImagePullSecretAttachment(ctx context.Context, req *agentsv1.CreateImagePullSecretAttachmentRequest, opts ...grpc.CallOption) (*agentsv1.CreateImagePullSecretAttachmentResponse, error) {
+	return nil, status.Error(codes.Unimplemented, "not implemented")
+}
+
+func (f *fakeAgentsClient) GetImagePullSecretAttachment(ctx context.Context, req *agentsv1.GetImagePullSecretAttachmentRequest, opts ...grpc.CallOption) (*agentsv1.GetImagePullSecretAttachmentResponse, error) {
+	return nil, status.Error(codes.Unimplemented, "not implemented")
+}
+
+func (f *fakeAgentsClient) DeleteImagePullSecretAttachment(ctx context.Context, req *agentsv1.DeleteImagePullSecretAttachmentRequest, opts ...grpc.CallOption) (*agentsv1.DeleteImagePullSecretAttachmentResponse, error) {
+	return nil, status.Error(codes.Unimplemented, "not implemented")
+}
+
+func (f *fakeAgentsClient) ListImagePullSecretAttachments(ctx context.Context, req *agentsv1.ListImagePullSecretAttachmentsRequest, opts ...grpc.CallOption) (*agentsv1.ListImagePullSecretAttachmentsResponse, error) {
+	return nil, status.Error(codes.Unimplemented, "not implemented")
+}
+
+type fakeAppProxyOrganizationsClient struct {
+	listMyMemberships func(ctx context.Context, req *organizationsv1.ListMyMembershipsRequest, opts ...grpc.CallOption) (*organizationsv1.ListMyMembershipsResponse, error)
+}
+
+func (f *fakeAppProxyOrganizationsClient) CreateOrganization(ctx context.Context, req *organizationsv1.CreateOrganizationRequest, opts ...grpc.CallOption) (*organizationsv1.CreateOrganizationResponse, error) {
+	return nil, status.Error(codes.Unimplemented, "not implemented")
+}
+
+func (f *fakeAppProxyOrganizationsClient) GetOrganization(ctx context.Context, req *organizationsv1.GetOrganizationRequest, opts ...grpc.CallOption) (*organizationsv1.GetOrganizationResponse, error) {
+	return nil, status.Error(codes.Unimplemented, "not implemented")
+}
+
+func (f *fakeAppProxyOrganizationsClient) UpdateOrganization(ctx context.Context, req *organizationsv1.UpdateOrganizationRequest, opts ...grpc.CallOption) (*organizationsv1.UpdateOrganizationResponse, error) {
+	return nil, status.Error(codes.Unimplemented, "not implemented")
+}
+
+func (f *fakeAppProxyOrganizationsClient) DeleteOrganization(ctx context.Context, req *organizationsv1.DeleteOrganizationRequest, opts ...grpc.CallOption) (*organizationsv1.DeleteOrganizationResponse, error) {
+	return nil, status.Error(codes.Unimplemented, "not implemented")
+}
+
+func (f *fakeAppProxyOrganizationsClient) ListOrganizations(ctx context.Context, req *organizationsv1.ListOrganizationsRequest, opts ...grpc.CallOption) (*organizationsv1.ListOrganizationsResponse, error) {
+	return nil, status.Error(codes.Unimplemented, "not implemented")
+}
+
+func (f *fakeAppProxyOrganizationsClient) ListAccessibleOrganizations(ctx context.Context, req *organizationsv1.ListAccessibleOrganizationsRequest, opts ...grpc.CallOption) (*organizationsv1.ListAccessibleOrganizationsResponse, error) {
+	return nil, status.Error(codes.Unimplemented, "not implemented")
+}
+
+func (f *fakeAppProxyOrganizationsClient) CreateMembership(ctx context.Context, req *organizationsv1.CreateMembershipRequest, opts ...grpc.CallOption) (*organizationsv1.CreateMembershipResponse, error) {
+	return nil, status.Error(codes.Unimplemented, "not implemented")
+}
+
+func (f *fakeAppProxyOrganizationsClient) AcceptMembership(ctx context.Context, req *organizationsv1.AcceptMembershipRequest, opts ...grpc.CallOption) (*organizationsv1.AcceptMembershipResponse, error) {
+	return nil, status.Error(codes.Unimplemented, "not implemented")
+}
+
+func (f *fakeAppProxyOrganizationsClient) DeclineMembership(ctx context.Context, req *organizationsv1.DeclineMembershipRequest, opts ...grpc.CallOption) (*organizationsv1.DeclineMembershipResponse, error) {
+	return nil, status.Error(codes.Unimplemented, "not implemented")
+}
+
+func (f *fakeAppProxyOrganizationsClient) RemoveMembership(ctx context.Context, req *organizationsv1.RemoveMembershipRequest, opts ...grpc.CallOption) (*organizationsv1.RemoveMembershipResponse, error) {
+	return nil, status.Error(codes.Unimplemented, "not implemented")
+}
+
+func (f *fakeAppProxyOrganizationsClient) UpdateMembershipRole(ctx context.Context, req *organizationsv1.UpdateMembershipRoleRequest, opts ...grpc.CallOption) (*organizationsv1.UpdateMembershipRoleResponse, error) {
+	return nil, status.Error(codes.Unimplemented, "not implemented")
+}
+
+func (f *fakeAppProxyOrganizationsClient) ListMembers(ctx context.Context, req *organizationsv1.ListMembersRequest, opts ...grpc.CallOption) (*organizationsv1.ListMembersResponse, error) {
+	return nil, status.Error(codes.Unimplemented, "not implemented")
+}
+
+func (f *fakeAppProxyOrganizationsClient) ListMyMemberships(ctx context.Context, req *organizationsv1.ListMyMembershipsRequest, opts ...grpc.CallOption) (*organizationsv1.ListMyMembershipsResponse, error) {
+	if f.listMyMemberships != nil {
+		return f.listMyMemberships(ctx, req, opts...)
+	}
+	return nil, status.Error(codes.Unimplemented, "not implemented")
+}
+
+func (f *fakeAppProxyOrganizationsClient) SetMyOrgNickname(ctx context.Context, req *organizationsv1.SetMyOrgNicknameRequest, opts ...grpc.CallOption) (*organizationsv1.SetMyOrgNicknameResponse, error) {
 	return nil, status.Error(codes.Unimplemented, "not implemented")
 }
 
@@ -298,11 +546,13 @@ func TestAppProxyHandlerServeHTTP(t *testing.T) {
 	var gotIdentityType string
 	var gotInstallationID string
 	var gotPath string
+	var gotOrganizationID string
 
 	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		gotIdentityID = r.Header.Get(identity.MetadataKeyIdentityID)
 		gotIdentityType = r.Header.Get(identity.MetadataKeyIdentityType)
 		gotInstallationID = r.Header.Get(identity.MetadataKeyAppInstallationID)
+		gotOrganizationID = r.Header.Get(identity.MetadataKeyOrganizationID)
 		gotPath = r.URL.Path
 		w.Header().Set("X-Test", "ok")
 		w.WriteHeader(http.StatusOK)
@@ -318,6 +568,16 @@ func TestAppProxyHandlerServeHTTP(t *testing.T) {
 			return (&net.Dialer{}).DialContext(ctx, "tcp", serverAddr)
 		},
 	}
+	agentsClient := &fakeAgentsClient{
+		resolveAgentIdentity: func(ctx context.Context, req *agentsv1.ResolveAgentIdentityRequest, opts ...grpc.CallOption) (*agentsv1.ResolveAgentIdentityResponse, error) {
+			return &agentsv1.ResolveAgentIdentityResponse{OrganizationId: "org-1"}, nil
+		},
+	}
+	organizationsClient := &fakeAppProxyOrganizationsClient{
+		listMyMemberships: func(ctx context.Context, req *organizationsv1.ListMyMembershipsRequest, opts ...grpc.CallOption) (*organizationsv1.ListMyMembershipsResponse, error) {
+			return &organizationsv1.ListMyMembershipsResponse{Memberships: []*organizationsv1.Membership{{OrganizationId: "org-1"}}}, nil
+		},
+	}
 	appsClient := &fakeAppsClient{
 		getInstallationBySlug: func(ctx context.Context, req *appsv1.GetInstallationBySlugRequest, opts ...grpc.CallOption) (*appsv1.GetInstallationBySlugResponse, error) {
 			return &appsv1.GetInstallationBySlugResponse{Installation: &appsv1.Installation{
@@ -330,17 +590,19 @@ func TestAppProxyHandlerServeHTTP(t *testing.T) {
 		},
 	}
 	handler := &AppProxyHandler{
-		apps:     appsClient,
-		client:   &http.Client{Transport: transport},
-		cache:    make(map[string]cachedInstallation),
-		cacheTTL: time.Minute,
+		apps:          appsClient,
+		agents:        agentsClient,
+		organizations: organizationsClient,
+		client:        &http.Client{Transport: transport},
+		cache:         make(map[string]cachedInstallation),
+		cacheTTL:      time.Minute,
 	}
 
-	resolved := identity.ResolvedIdentity{IdentityID: "identity-1", IdentityType: identity.IdentityTypeUser}
+	resolved := identity.ResolvedIdentity{IdentityID: "identity-1", IdentityType: identity.IdentityTypeAgent}
 	req := httptest.NewRequest(http.MethodGet, "/apps/app-slug/health", nil)
 	req = req.WithContext(identity.WithIdentity(req.Context(), resolved))
 	resp := httptest.NewRecorder()
-	req.Header.Set(identity.MetadataKeyOrganizationID, "org-1")
+	req.Header.Set(identity.MetadataKeyOrganizationID, "org-override")
 
 	handler.ServeHTTP(resp, req)
 
@@ -362,25 +624,29 @@ func TestAppProxyHandlerServeHTTP(t *testing.T) {
 	if gotInstallationID != "inst-1" {
 		t.Fatalf("expected installation header %q, got %q", "inst-1", gotInstallationID)
 	}
+	if gotOrganizationID != "" {
+		t.Fatalf("expected organization header stripped, got %q", gotOrganizationID)
+	}
 	if gotPath != "/health" {
 		t.Fatalf("expected proxied path %q, got %q", "/health", gotPath)
 	}
 }
 
 func TestAppProxyHandlerServeHTTPMissingOrgID(t *testing.T) {
-	handler := &AppProxyHandler{}
+	appsClient := &fakeAppsClient{}
+	handler := &AppProxyHandler{apps: appsClient}
 	req := httptest.NewRequest(http.MethodGet, "/apps/app-slug/health", nil)
 	resp := httptest.NewRecorder()
 
 	handler.ServeHTTP(resp, req)
 
-	if resp.Code != http.StatusBadRequest {
-		t.Fatalf("expected status %d, got %d", http.StatusBadRequest, resp.Code)
+	if resp.Code != http.StatusUnauthorized {
+		t.Fatalf("expected status %d, got %d", http.StatusUnauthorized, resp.Code)
 	}
 }
 
 func TestAppProxyHandlerServeHTTPInvalidPath(t *testing.T) {
-	handler := &AppProxyHandler{}
+	handler := &AppProxyHandler{apps: &fakeAppsClient{}}
 	req := httptest.NewRequest(http.MethodGet, "/apps/app-slug", nil)
 	resp := httptest.NewRecorder()
 

--- a/internal/gateway/appproxy_test.go
+++ b/internal/gateway/appproxy_test.go
@@ -10,7 +10,6 @@ import (
 
 	agentsv1 "github.com/agynio/gateway/gen/agynio/api/agents/v1"
 	appsv1 "github.com/agynio/gateway/gen/agynio/api/apps/v1"
-	organizationsv1 "github.com/agynio/gateway/gen/agynio/api/organizations/v1"
 	"github.com/agynio/gateway/internal/identity"
 	"google.golang.org/grpc"
 	"google.golang.org/grpc/codes"
@@ -291,68 +290,6 @@ func (f *fakeAgentsClient) ListImagePullSecretAttachments(ctx context.Context, r
 	return nil, status.Error(codes.Unimplemented, "not implemented")
 }
 
-type fakeAppProxyOrganizationsClient struct {
-	listMyMemberships func(ctx context.Context, req *organizationsv1.ListMyMembershipsRequest, opts ...grpc.CallOption) (*organizationsv1.ListMyMembershipsResponse, error)
-}
-
-func (f *fakeAppProxyOrganizationsClient) CreateOrganization(ctx context.Context, req *organizationsv1.CreateOrganizationRequest, opts ...grpc.CallOption) (*organizationsv1.CreateOrganizationResponse, error) {
-	return nil, status.Error(codes.Unimplemented, "not implemented")
-}
-
-func (f *fakeAppProxyOrganizationsClient) GetOrganization(ctx context.Context, req *organizationsv1.GetOrganizationRequest, opts ...grpc.CallOption) (*organizationsv1.GetOrganizationResponse, error) {
-	return nil, status.Error(codes.Unimplemented, "not implemented")
-}
-
-func (f *fakeAppProxyOrganizationsClient) UpdateOrganization(ctx context.Context, req *organizationsv1.UpdateOrganizationRequest, opts ...grpc.CallOption) (*organizationsv1.UpdateOrganizationResponse, error) {
-	return nil, status.Error(codes.Unimplemented, "not implemented")
-}
-
-func (f *fakeAppProxyOrganizationsClient) DeleteOrganization(ctx context.Context, req *organizationsv1.DeleteOrganizationRequest, opts ...grpc.CallOption) (*organizationsv1.DeleteOrganizationResponse, error) {
-	return nil, status.Error(codes.Unimplemented, "not implemented")
-}
-
-func (f *fakeAppProxyOrganizationsClient) ListOrganizations(ctx context.Context, req *organizationsv1.ListOrganizationsRequest, opts ...grpc.CallOption) (*organizationsv1.ListOrganizationsResponse, error) {
-	return nil, status.Error(codes.Unimplemented, "not implemented")
-}
-
-func (f *fakeAppProxyOrganizationsClient) ListAccessibleOrganizations(ctx context.Context, req *organizationsv1.ListAccessibleOrganizationsRequest, opts ...grpc.CallOption) (*organizationsv1.ListAccessibleOrganizationsResponse, error) {
-	return nil, status.Error(codes.Unimplemented, "not implemented")
-}
-
-func (f *fakeAppProxyOrganizationsClient) CreateMembership(ctx context.Context, req *organizationsv1.CreateMembershipRequest, opts ...grpc.CallOption) (*organizationsv1.CreateMembershipResponse, error) {
-	return nil, status.Error(codes.Unimplemented, "not implemented")
-}
-
-func (f *fakeAppProxyOrganizationsClient) AcceptMembership(ctx context.Context, req *organizationsv1.AcceptMembershipRequest, opts ...grpc.CallOption) (*organizationsv1.AcceptMembershipResponse, error) {
-	return nil, status.Error(codes.Unimplemented, "not implemented")
-}
-
-func (f *fakeAppProxyOrganizationsClient) DeclineMembership(ctx context.Context, req *organizationsv1.DeclineMembershipRequest, opts ...grpc.CallOption) (*organizationsv1.DeclineMembershipResponse, error) {
-	return nil, status.Error(codes.Unimplemented, "not implemented")
-}
-
-func (f *fakeAppProxyOrganizationsClient) RemoveMembership(ctx context.Context, req *organizationsv1.RemoveMembershipRequest, opts ...grpc.CallOption) (*organizationsv1.RemoveMembershipResponse, error) {
-	return nil, status.Error(codes.Unimplemented, "not implemented")
-}
-
-func (f *fakeAppProxyOrganizationsClient) UpdateMembershipRole(ctx context.Context, req *organizationsv1.UpdateMembershipRoleRequest, opts ...grpc.CallOption) (*organizationsv1.UpdateMembershipRoleResponse, error) {
-	return nil, status.Error(codes.Unimplemented, "not implemented")
-}
-
-func (f *fakeAppProxyOrganizationsClient) ListMembers(ctx context.Context, req *organizationsv1.ListMembersRequest, opts ...grpc.CallOption) (*organizationsv1.ListMembersResponse, error) {
-	return nil, status.Error(codes.Unimplemented, "not implemented")
-}
-
-func (f *fakeAppProxyOrganizationsClient) ListMyMemberships(ctx context.Context, req *organizationsv1.ListMyMembershipsRequest, opts ...grpc.CallOption) (*organizationsv1.ListMyMembershipsResponse, error) {
-	if f.listMyMemberships != nil {
-		return f.listMyMemberships(ctx, req, opts...)
-	}
-	return nil, status.Error(codes.Unimplemented, "not implemented")
-}
-
-func (f *fakeAppProxyOrganizationsClient) SetMyOrgNickname(ctx context.Context, req *organizationsv1.SetMyOrgNicknameRequest, opts ...grpc.CallOption) (*organizationsv1.SetMyOrgNicknameResponse, error) {
-	return nil, status.Error(codes.Unimplemented, "not implemented")
-}
 
 func TestParseAppProxyPath(t *testing.T) {
 	tests := []struct {
@@ -573,11 +510,6 @@ func TestAppProxyHandlerServeHTTP(t *testing.T) {
 			return &agentsv1.ResolveAgentIdentityResponse{OrganizationId: "org-1"}, nil
 		},
 	}
-	organizationsClient := &fakeAppProxyOrganizationsClient{
-		listMyMemberships: func(ctx context.Context, req *organizationsv1.ListMyMembershipsRequest, opts ...grpc.CallOption) (*organizationsv1.ListMyMembershipsResponse, error) {
-			return &organizationsv1.ListMyMembershipsResponse{Memberships: []*organizationsv1.Membership{{OrganizationId: "org-1"}}}, nil
-		},
-	}
 	appsClient := &fakeAppsClient{
 		getInstallationBySlug: func(ctx context.Context, req *appsv1.GetInstallationBySlugRequest, opts ...grpc.CallOption) (*appsv1.GetInstallationBySlugResponse, error) {
 			return &appsv1.GetInstallationBySlugResponse{Installation: &appsv1.Installation{
@@ -590,12 +522,11 @@ func TestAppProxyHandlerServeHTTP(t *testing.T) {
 		},
 	}
 	handler := &AppProxyHandler{
-		apps:          appsClient,
-		agents:        agentsClient,
-		organizations: organizationsClient,
-		client:        &http.Client{Transport: transport},
-		cache:         make(map[string]cachedInstallation),
-		cacheTTL:      time.Minute,
+		apps:     appsClient,
+		agents:   agentsClient,
+		client:   &http.Client{Transport: transport},
+		cache:    make(map[string]cachedInstallation),
+		cacheTTL: time.Minute,
 	}
 
 	resolved := identity.ResolvedIdentity{IdentityID: "identity-1", IdentityType: identity.IdentityTypeAgent}
@@ -642,6 +573,21 @@ func TestAppProxyHandlerServeHTTPMissingOrgID(t *testing.T) {
 
 	if resp.Code != http.StatusUnauthorized {
 		t.Fatalf("expected status %d, got %d", http.StatusUnauthorized, resp.Code)
+	}
+}
+
+func TestAppProxyHandlerServeHTTPUserIdentityUnsupported(t *testing.T) {
+	appsClient := &fakeAppsClient{}
+	agentsClient := &fakeAgentsClient{}
+	handler := &AppProxyHandler{apps: appsClient, agents: agentsClient}
+	req := httptest.NewRequest(http.MethodGet, "/apps/app-slug/health", nil)
+	req = req.WithContext(identity.WithIdentity(req.Context(), identity.ResolvedIdentity{IdentityID: "user-1", IdentityType: identity.IdentityTypeUser}))
+	resp := httptest.NewRecorder()
+
+	handler.ServeHTTP(resp, req)
+
+	if resp.Code != http.StatusPreconditionFailed {
+		t.Fatalf("expected status %d, got %d", http.StatusPreconditionFailed, resp.Code)
 	}
 }
 


### PR DESCRIPTION
## Summary
- derive organization id from resolved network identity (agent/user) for app proxy
- remove inbound x-* headers before forwarding and inject gateway-owned identity headers
- update app proxy tests for org derivation and header stripping

## Testing
- buf generate buf.build/agynio/api --include-imports --path agynio/api/agents/v1 --path agynio/api/apps/v1 --path agynio/api/threads/v1 --path agynio/api/chat/v1 --path agynio/api/notifications/v1 --path agynio/api/files/v1 --path agynio/api/agent_state/v1 --path agynio/api/token_counting/v1 --path agynio/api/metering/v1 --path agynio/api/llm/v1 --path agynio/api/secrets/v1 --path agynio/api/identity/v1 --path agynio/api/tracing/v1 --path agynio/api/users/v1 --path agynio/api/organizations/v1 --path agynio/api/runners/v1 --path agynio/api/ziti_management/v1 --path agynio/api/gateway/v1
- go test ./...

## Issue
#29