### PR TITLE
ci: align e2e workflow

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -6,12 +6,12 @@ on:
       - main
   pull_request:
 
+permissions:
+  contents: read
+
 jobs:
   build:
     runs-on: ubuntu-latest
-    permissions:
-      contents: read
-      packages: read
     env:
       GO111MODULE: on
     steps:

--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -33,6 +33,7 @@ jobs:
       - name: Run E2E tests
         uses: agynio/e2e/.github/actions/run-tests@main
         with:
+          ref: noa/gateway-178-e2e
           service: gateway
 
       - name: Restore ArgoCD auto-sync

--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -32,6 +32,8 @@ jobs:
 
       - name: Run E2E tests
         uses: agynio/e2e/.github/actions/run-tests@main
+        env:
+          E2E_SUITES: go-core go-terraform playwright
         with:
           ref: noa/gateway-178-e2e
           service: gateway

--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -1,15 +1,22 @@
 name: E2E
 
 on:
+  push:
+    branches: [main]
   pull_request:
   workflow_dispatch:
+
+permissions:
+  contents: read
+
+concurrency:
+  group: e2e-${{ github.event_name == 'pull_request' && github.event.pull_request.number || github.sha }}
+  cancel-in-progress: true
 
 jobs:
   e2e:
     runs-on: ubuntu-latest
     timeout-minutes: 60
-    permissions:
-      contents: read
     steps:
       - name: Checkout
         uses: actions/checkout@v4
@@ -20,7 +27,7 @@ jobs:
       - name: Setup DevSpace
         uses: agynio/e2e/.github/actions/setup-devspace@main
 
-      - name: Deploy from source
+      - name: Deploy gateway from source
         run: devspace dev
 
       - name: Run E2E tests

--- a/devspace.yaml
+++ b/devspace.yaml
@@ -121,14 +121,20 @@ dev:
               - .devspace/
               - gateway.log
               - gateway.pid
+              - bootstrap/
+              - e2e/
             uploadExcludePaths:
               - .git/
               - /gen/
               - dist/
+              - bootstrap/
+              - e2e/
             downloadExcludePaths:
               - .git/
               - /gen/
               - dist/
+              - bootstrap/
+              - e2e/
         logs:
           enabled: true
           lastLines: 200

--- a/internal/gateway/agents.go
+++ b/internal/gateway/agents.go
@@ -47,6 +47,38 @@ func (g *Gateway) ListAgents(ctx context.Context, req *connect.Request[agentsv1.
 	return connect.NewResponse(resp), nil
 }
 
+func (g *Gateway) SetAgentRole(ctx context.Context, req *connect.Request[agentsv1.SetAgentRoleRequest]) (*connect.Response[agentsv1.SetAgentRoleResponse], error) {
+	resp, err := g.agents.SetAgentRole(ctx, req.Msg)
+	if err != nil {
+		return nil, toConnectError(err)
+	}
+	return connect.NewResponse(resp), nil
+}
+
+func (g *Gateway) RemoveAgentRole(ctx context.Context, req *connect.Request[agentsv1.RemoveAgentRoleRequest]) (*connect.Response[agentsv1.RemoveAgentRoleResponse], error) {
+	resp, err := g.agents.RemoveAgentRole(ctx, req.Msg)
+	if err != nil {
+		return nil, toConnectError(err)
+	}
+	return connect.NewResponse(resp), nil
+}
+
+func (g *Gateway) ListAgentRoles(ctx context.Context, req *connect.Request[agentsv1.ListAgentRolesRequest]) (*connect.Response[agentsv1.ListAgentRolesResponse], error) {
+	resp, err := g.agents.ListAgentRoles(ctx, req.Msg)
+	if err != nil {
+		return nil, toConnectError(err)
+	}
+	return connect.NewResponse(resp), nil
+}
+
+func (g *Gateway) ListMyAgentRoles(ctx context.Context, req *connect.Request[agentsv1.ListMyAgentRolesRequest]) (*connect.Response[agentsv1.ListMyAgentRolesResponse], error) {
+	resp, err := g.agents.ListMyAgentRoles(ctx, req.Msg)
+	if err != nil {
+		return nil, toConnectError(err)
+	}
+	return connect.NewResponse(resp), nil
+}
+
 func (g *Gateway) CreateVolume(ctx context.Context, req *connect.Request[agentsv1.CreateVolumeRequest]) (*connect.Response[agentsv1.CreateVolumeResponse], error) {
 	resp, err := g.agents.CreateVolume(ctx, req.Msg)
 	if err != nil {

--- a/internal/gateway/appproxy_test.go
+++ b/internal/gateway/appproxy_test.go
@@ -138,6 +138,22 @@ func (f *fakeAgentsClient) ListAgents(ctx context.Context, req *agentsv1.ListAge
 	return nil, status.Error(codes.Unimplemented, "not implemented")
 }
 
+func (f *fakeAgentsClient) SetAgentRole(ctx context.Context, req *agentsv1.SetAgentRoleRequest, opts ...grpc.CallOption) (*agentsv1.SetAgentRoleResponse, error) {
+	return nil, status.Error(codes.Unimplemented, "not implemented")
+}
+
+func (f *fakeAgentsClient) RemoveAgentRole(ctx context.Context, req *agentsv1.RemoveAgentRoleRequest, opts ...grpc.CallOption) (*agentsv1.RemoveAgentRoleResponse, error) {
+	return nil, status.Error(codes.Unimplemented, "not implemented")
+}
+
+func (f *fakeAgentsClient) ListAgentRoles(ctx context.Context, req *agentsv1.ListAgentRolesRequest, opts ...grpc.CallOption) (*agentsv1.ListAgentRolesResponse, error) {
+	return nil, status.Error(codes.Unimplemented, "not implemented")
+}
+
+func (f *fakeAgentsClient) ListMyAgentRoles(ctx context.Context, req *agentsv1.ListMyAgentRolesRequest, opts ...grpc.CallOption) (*agentsv1.ListMyAgentRolesResponse, error) {
+	return nil, status.Error(codes.Unimplemented, "not implemented")
+}
+
 func (f *fakeAgentsClient) CreateVolume(ctx context.Context, req *agentsv1.CreateVolumeRequest, opts ...grpc.CallOption) (*agentsv1.CreateVolumeResponse, error) {
 	return nil, status.Error(codes.Unimplemented, "not implemented")
 }
@@ -289,7 +305,6 @@ func (f *fakeAgentsClient) DeleteImagePullSecretAttachment(ctx context.Context, 
 func (f *fakeAgentsClient) ListImagePullSecretAttachments(ctx context.Context, req *agentsv1.ListImagePullSecretAttachmentsRequest, opts ...grpc.CallOption) (*agentsv1.ListImagePullSecretAttachmentsResponse, error) {
 	return nil, status.Error(codes.Unimplemented, "not implemented")
 }
-
 
 func TestParseAppProxyPath(t *testing.T) {
 	tests := []struct {


### PR DESCRIPTION
## Summary
- Aligns E2E workflow with centralized architecture: provision via `agynio/bootstrap/.github/actions/provision@main`, deploy gateway from source with `devspace dev`, then run `agynio/e2e/.github/actions/run-tests@main`.
- Adds E2E coverage on pushes to `main` and concurrency cancellation.
- Removes unnecessary package permissions from PR CI and keeps read-only workflow permissions.
- Verified PR workflows do not build/publish images/charts and do not override bootstrap cluster environment.
- Adds gateway pass-through methods and fake client stubs for current generated Agents role RPCs so local validation succeeds after generation.
- Temporarily validates against `agynio/e2e#107`, which carries the centralized chat-app CreateAgent availability serialization fix needed by current Agents API.

Closes #177

## Test & Lint Summary
- `actionlint .github/workflows/ci.yml .github/workflows/e2e.yml .github/workflows/release.yml` — passed with no errors.
- `yamllint -d '{extends: default, rules: {line-length: disable, document-start: disable, truthy: disable}}' .github/workflows/ci.yml .github/workflows/e2e.yml .github/workflows/release.yml devspace.yaml` — passed with no errors.
- `buf generate buf.build/agynio/api --include-imports --path agynio/api/agents/v1 --path agynio/api/apps/v1 --path agynio/api/threads/v1 --path agynio/api/chat/v1 --path agynio/api/notifications/v1 --path agynio/api/files/v1 --path agynio/api/agent_state/v1 --path agynio/api/token_counting/v1 --path agynio/api/metering/v1 --path agynio/api/llm/v1 --path agynio/api/secrets/v1 --path agynio/api/identity/v1 --path agynio/api/tracing/v1 --path agynio/api/users/v1 --path agynio/api/organizations/v1 --path agynio/api/runners/v1 --path agynio/api/expose/v1 --path agynio/api/ziti_management/v1 --path agynio/api/gateway/v1` — passed.
- `go vet ./...` — passed with no errors.
- `go test ./...` — 142 passed, 0 failed, 0 skipped.
- `go build ./...` — passed.
- Local bootstrap/E2E attempt: blocked by workspace Docker/k3d mount permissions (`sysfs` mount operation not permitted); full E2E validated in GitHub Actions.

## Notes
- Initial local `go vet ./...` exposed missing gateway handlers/fakes for current generated Agents role RPCs; added strict pass-through implementations and test stubs, then reran successfully.