### PR TITLE
ci(e2e): use default e2e test ref

### DIFF
--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -35,7 +35,6 @@ jobs:
         env:
           E2E_SUITES: go-core go-terraform playwright
         with:
-          ref: noa/gateway-178-e2e
           service: gateway
 
       - name: Restore ArgoCD auto-sync


### PR DESCRIPTION
## Summary
- Remove the hardcoded `ref: noa/gateway-178-e2e` override from the E2E workflow.
- Let `agynio/e2e/.github/actions/run-tests` use its default ref (`main`) so checkout does not fail on the deleted/non-existent branch.

Closes #181

## Test & Lint Summary
- `go vet ./...`: passed with no errors.
- `go test ./...`: 142 passed / 0 failed / 0 skipped.