### PR TITLE
Remove E2E ref input

### DIFF
--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -35,7 +35,6 @@ jobs:
         env:
           E2E_SUITES: go-core go-terraform playwright
         with:
-          ref: noa/gateway-178-e2e
           service: gateway
 
       - name: Restore ArgoCD auto-sync


### PR DESCRIPTION
## Summary
- Remove the unsupported `ref` input from the E2E `run-tests` action call.
- Keep the gateway service and E2E suite configuration unchanged.

Closes #183

## Test & Lint Summary
- `actionlint .github/workflows/e2e.yml`: passed with no errors.
- `git diff --check`: passed with no whitespace errors.
- `go vet ./...`: passed with no errors.
- `go test ./...`: 10 passed / 0 failed / 47 skipped (packages with no test files).

Note: Generated stubs were produced locally with `buf generate` for validation only; no generated files are committed.