### PR TITLE
fix(gateway): forward identity downstream

### DIFF
--- a/internal/gateway/downstream.go
+++ b/internal/gateway/downstream.go
@@ -1,0 +1,11 @@
+package gateway
+
+import (
+	"context"
+
+	"github.com/agynio/gateway/internal/identity"
+)
+
+func downstreamContext(ctx context.Context) context.Context {
+	return identity.AppendToOutgoingContext(ctx)
+}

--- a/internal/gateway/expose.go
+++ b/internal/gateway/expose.go
@@ -16,7 +16,7 @@ func NewExposeGateway(expose exposev1.ExposeServiceClient) *ExposeGateway {
 }
 
 func (g *ExposeGateway) AddExposure(ctx context.Context, req *connect.Request[exposev1.AddExposureRequest]) (*connect.Response[exposev1.AddExposureResponse], error) {
-	resp, err := g.expose.AddExposure(ctx, req.Msg)
+	resp, err := g.expose.AddExposure(downstreamContext(ctx), req.Msg)
 	if err != nil {
 		return nil, toConnectError(err)
 	}
@@ -24,7 +24,7 @@ func (g *ExposeGateway) AddExposure(ctx context.Context, req *connect.Request[ex
 }
 
 func (g *ExposeGateway) RemoveExposure(ctx context.Context, req *connect.Request[exposev1.RemoveExposureRequest]) (*connect.Response[exposev1.RemoveExposureResponse], error) {
-	resp, err := g.expose.RemoveExposure(ctx, req.Msg)
+	resp, err := g.expose.RemoveExposure(downstreamContext(ctx), req.Msg)
 	if err != nil {
 		return nil, toConnectError(err)
 	}
@@ -32,7 +32,7 @@ func (g *ExposeGateway) RemoveExposure(ctx context.Context, req *connect.Request
 }
 
 func (g *ExposeGateway) ListExposures(ctx context.Context, req *connect.Request[exposev1.ListExposuresRequest]) (*connect.Response[exposev1.ListExposuresResponse], error) {
-	resp, err := g.expose.ListExposures(ctx, req.Msg)
+	resp, err := g.expose.ListExposures(downstreamContext(ctx), req.Msg)
 	if err != nil {
 		return nil, toConnectError(err)
 	}

--- a/internal/gateway/expose_test.go
+++ b/internal/gateway/expose_test.go
@@ -6,7 +6,9 @@ import (
 
 	"connectrpc.com/connect"
 	exposev1 "github.com/agynio/gateway/gen/agynio/api/expose/v1"
+	"github.com/agynio/gateway/internal/identity"
 	"google.golang.org/grpc"
+	"google.golang.org/grpc/metadata"
 )
 
 type fakeExposeClient struct {
@@ -14,6 +16,7 @@ type fakeExposeClient struct {
 	addExposureResp     *exposev1.AddExposureResponse
 	addExposureErr      error
 	addExposureCalls    int
+	addExposureMetadata metadata.MD
 	removeExposureReq   *exposev1.RemoveExposureRequest
 	removeExposureResp  *exposev1.RemoveExposureResponse
 	removeExposureErr   error
@@ -27,6 +30,7 @@ type fakeExposeClient struct {
 func (f *fakeExposeClient) AddExposure(ctx context.Context, in *exposev1.AddExposureRequest, opts ...grpc.CallOption) (*exposev1.AddExposureResponse, error) {
 	f.addExposureCalls++
 	f.addExposureReq = in
+	f.addExposureMetadata, _ = metadata.FromOutgoingContext(ctx)
 	if f.addExposureErr != nil {
 		return nil, f.addExposureErr
 	}
@@ -87,6 +91,32 @@ func TestExposeGatewayAddExposureForwardsRequest(t *testing.T) {
 	if resp.Msg != client.addExposureResp {
 		t.Fatalf("expected response to be forwarded")
 	}
+}
+
+func TestExposeGatewayAddExposurePropagatesIdentityMetadata(t *testing.T) {
+	client := &fakeExposeClient{addExposureResp: &exposev1.AddExposureResponse{}}
+	gateway := NewExposeGateway(client)
+	resolved := identity.ResolvedIdentity{
+		IdentityID:   "agent-1",
+		IdentityType: identity.IdentityTypeAgent,
+		WorkloadID:   "workload-1",
+	}
+	ctx := metadata.AppendToOutgoingContext(
+		context.Background(),
+		identity.MetadataKeyIdentityID, "stale-identity",
+		identity.MetadataKeyIdentityType, string(identity.IdentityTypeUser),
+		identity.MetadataKeyWorkloadID, "stale-workload",
+	)
+	ctx = identity.WithIdentity(ctx, resolved)
+
+	_, err := gateway.AddExposure(ctx, connect.NewRequest(&exposev1.AddExposureRequest{Port: 8080}))
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	assertMetadataValue(t, client.addExposureMetadata, identity.MetadataKeyIdentityID, resolved.IdentityID)
+	assertMetadataValue(t, client.addExposureMetadata, identity.MetadataKeyIdentityType, string(resolved.IdentityType))
+	assertMetadataValue(t, client.addExposureMetadata, identity.MetadataKeyWorkloadID, resolved.WorkloadID)
 }
 
 func TestExposeGatewayRemoveExposureForwardsRequest(t *testing.T) {

--- a/internal/gateway/notifications.go
+++ b/internal/gateway/notifications.go
@@ -17,7 +17,7 @@ func (g *Gateway) Subscribe(ctx context.Context, req *connect.Request[notificati
 		return toConnectError(status.Error(codes.Unauthenticated, "identity not available"))
 	}
 
-	grpcStream, err := g.notifications.Subscribe(identity.AppendToOutgoingContext(ctx), req.Msg)
+	grpcStream, err := g.notifications.Subscribe(downstreamContext(ctx), req.Msg)
 	if err != nil {
 		return toConnectError(err)
 	}

--- a/internal/gateway/runners.go
+++ b/internal/gateway/runners.go
@@ -19,7 +19,7 @@ func NewRunnersGateway(runners runnersv1.RunnersServiceClient) *RunnersGateway {
 }
 
 func (g *RunnersGateway) RegisterRunner(ctx context.Context, req *connect.Request[runnersv1.RegisterRunnerRequest]) (*connect.Response[runnersv1.RegisterRunnerResponse], error) {
-	resp, err := g.runners.RegisterRunner(ctx, req.Msg)
+	resp, err := g.runners.RegisterRunner(downstreamContext(ctx), req.Msg)
 	if err != nil {
 		return nil, toConnectError(err)
 	}
@@ -27,7 +27,7 @@ func (g *RunnersGateway) RegisterRunner(ctx context.Context, req *connect.Reques
 }
 
 func (g *RunnersGateway) EnrollRunner(ctx context.Context, req *connect.Request[runnersv1.EnrollRunnerRequest]) (*connect.Response[runnersv1.EnrollRunnerResponse], error) {
-	resp, err := g.runners.EnrollRunner(ctx, req.Msg)
+	resp, err := g.runners.EnrollRunner(downstreamContext(ctx), req.Msg)
 	if err != nil {
 		return nil, toConnectError(err)
 	}
@@ -35,7 +35,7 @@ func (g *RunnersGateway) EnrollRunner(ctx context.Context, req *connect.Request[
 }
 
 func (g *RunnersGateway) GetRunner(ctx context.Context, req *connect.Request[runnersv1.GetRunnerRequest]) (*connect.Response[runnersv1.GetRunnerResponse], error) {
-	resp, err := g.runners.GetRunner(ctx, req.Msg)
+	resp, err := g.runners.GetRunner(downstreamContext(ctx), req.Msg)
 	if err != nil {
 		return nil, toConnectError(err)
 	}
@@ -43,7 +43,7 @@ func (g *RunnersGateway) GetRunner(ctx context.Context, req *connect.Request[run
 }
 
 func (g *RunnersGateway) ListRunners(ctx context.Context, req *connect.Request[runnersv1.ListRunnersRequest]) (*connect.Response[runnersv1.ListRunnersResponse], error) {
-	resp, err := g.runners.ListRunners(ctx, req.Msg)
+	resp, err := g.runners.ListRunners(downstreamContext(ctx), req.Msg)
 	if err != nil {
 		return nil, toConnectError(err)
 	}
@@ -51,7 +51,7 @@ func (g *RunnersGateway) ListRunners(ctx context.Context, req *connect.Request[r
 }
 
 func (g *RunnersGateway) UpdateRunner(ctx context.Context, req *connect.Request[runnersv1.UpdateRunnerRequest]) (*connect.Response[runnersv1.UpdateRunnerResponse], error) {
-	resp, err := g.runners.UpdateRunner(ctx, req.Msg)
+	resp, err := g.runners.UpdateRunner(downstreamContext(ctx), req.Msg)
 	if err != nil {
 		return nil, toConnectError(err)
 	}
@@ -59,7 +59,7 @@ func (g *RunnersGateway) UpdateRunner(ctx context.Context, req *connect.Request[
 }
 
 func (g *RunnersGateway) DeleteRunner(ctx context.Context, req *connect.Request[runnersv1.DeleteRunnerRequest]) (*connect.Response[runnersv1.DeleteRunnerResponse], error) {
-	resp, err := g.runners.DeleteRunner(ctx, req.Msg)
+	resp, err := g.runners.DeleteRunner(downstreamContext(ctx), req.Msg)
 	if err != nil {
 		return nil, toConnectError(err)
 	}
@@ -67,7 +67,7 @@ func (g *RunnersGateway) DeleteRunner(ctx context.Context, req *connect.Request[
 }
 
 func (g *RunnersGateway) GetVolume(ctx context.Context, req *connect.Request[runnersv1.GetVolumeRequest]) (*connect.Response[runnersv1.GetVolumeResponse], error) {
-	resp, err := g.runners.GetVolume(ctx, req.Msg)
+	resp, err := g.runners.GetVolume(downstreamContext(ctx), req.Msg)
 	if err != nil {
 		return nil, toConnectError(err)
 	}
@@ -75,7 +75,7 @@ func (g *RunnersGateway) GetVolume(ctx context.Context, req *connect.Request[run
 }
 
 func (g *RunnersGateway) ListVolumes(ctx context.Context, req *connect.Request[runnersv1.ListVolumesRequest]) (*connect.Response[runnersv1.ListVolumesResponse], error) {
-	resp, err := g.runners.ListVolumes(ctx, req.Msg)
+	resp, err := g.runners.ListVolumes(downstreamContext(ctx), req.Msg)
 	if err != nil {
 		return nil, toConnectError(err)
 	}
@@ -83,7 +83,7 @@ func (g *RunnersGateway) ListVolumes(ctx context.Context, req *connect.Request[r
 }
 
 func (g *RunnersGateway) ListVolumesByThread(ctx context.Context, req *connect.Request[runnersv1.ListVolumesByThreadRequest]) (*connect.Response[runnersv1.ListVolumesByThreadResponse], error) {
-	resp, err := g.runners.ListVolumesByThread(ctx, req.Msg)
+	resp, err := g.runners.ListVolumesByThread(downstreamContext(ctx), req.Msg)
 	if err != nil {
 		return nil, toConnectError(err)
 	}
@@ -91,7 +91,7 @@ func (g *RunnersGateway) ListVolumesByThread(ctx context.Context, req *connect.R
 }
 
 func (g *RunnersGateway) ListWorkloadsByThread(ctx context.Context, req *connect.Request[runnersv1.ListWorkloadsByThreadRequest]) (*connect.Response[runnersv1.ListWorkloadsByThreadResponse], error) {
-	resp, err := g.runners.ListWorkloadsByThread(ctx, req.Msg)
+	resp, err := g.runners.ListWorkloadsByThread(downstreamContext(ctx), req.Msg)
 	if err != nil {
 		return nil, toConnectError(err)
 	}
@@ -99,7 +99,7 @@ func (g *RunnersGateway) ListWorkloadsByThread(ctx context.Context, req *connect
 }
 
 func (g *RunnersGateway) ListWorkloads(ctx context.Context, req *connect.Request[runnersv1.ListWorkloadsRequest]) (*connect.Response[runnersv1.ListWorkloadsResponse], error) {
-	resp, err := g.runners.ListWorkloads(ctx, req.Msg)
+	resp, err := g.runners.ListWorkloads(downstreamContext(ctx), req.Msg)
 	if err != nil {
 		return nil, toConnectError(err)
 	}
@@ -107,7 +107,7 @@ func (g *RunnersGateway) ListWorkloads(ctx context.Context, req *connect.Request
 }
 
 func (g *RunnersGateway) GetWorkload(ctx context.Context, req *connect.Request[runnersv1.GetWorkloadRequest]) (*connect.Response[runnersv1.GetWorkloadResponse], error) {
-	resp, err := g.runners.GetWorkload(ctx, req.Msg)
+	resp, err := g.runners.GetWorkload(downstreamContext(ctx), req.Msg)
 	if err != nil {
 		return nil, toConnectError(err)
 	}
@@ -115,7 +115,7 @@ func (g *RunnersGateway) GetWorkload(ctx context.Context, req *connect.Request[r
 }
 
 func (g *RunnersGateway) TouchWorkload(ctx context.Context, req *connect.Request[runnersv1.TouchWorkloadRequest]) (*connect.Response[runnersv1.TouchWorkloadResponse], error) {
-	resp, err := g.runners.TouchWorkload(ctx, req.Msg)
+	resp, err := g.runners.TouchWorkload(downstreamContext(ctx), req.Msg)
 	if err != nil {
 		return nil, toConnectError(err)
 	}
@@ -123,7 +123,7 @@ func (g *RunnersGateway) TouchWorkload(ctx context.Context, req *connect.Request
 }
 
 func (g *RunnersGateway) StreamWorkloadLogs(ctx context.Context, req *connect.Request[runnerv1.StreamWorkloadLogsRequest], stream *connect.ServerStream[runnerv1.StreamWorkloadLogsResponse]) error {
-	grpcStream, err := g.runners.StreamWorkloadLogs(ctx, req.Msg)
+	grpcStream, err := g.runners.StreamWorkloadLogs(downstreamContext(ctx), req.Msg)
 	if err != nil {
 		return toConnectError(err)
 	}

--- a/internal/gateway/runners_test.go
+++ b/internal/gateway/runners_test.go
@@ -12,6 +12,7 @@ import (
 	gatewayv1connect "github.com/agynio/gateway/gen/agynio/api/gateway/v1/gatewayv1connect"
 	runnerv1 "github.com/agynio/gateway/gen/agynio/api/runner/v1"
 	runnersv1 "github.com/agynio/gateway/gen/agynio/api/runners/v1"
+	"github.com/agynio/gateway/internal/identity"
 	"google.golang.org/grpc"
 	"google.golang.org/grpc/codes"
 	"google.golang.org/grpc/metadata"
@@ -66,6 +67,10 @@ func (f *fakeStream) RecvMsg(any) error {
 }
 
 type fakeRunnersClient struct {
+	getWorkload             func(ctx context.Context, req *runnersv1.GetWorkloadRequest) (*runnersv1.GetWorkloadResponse, error)
+	getWorkloadReq          *runnersv1.GetWorkloadRequest
+	getWorkloadMetadata     metadata.MD
+	getWorkloadCalls        int
 	streamWorkloadLogs      func(ctx context.Context, req *runnerv1.StreamWorkloadLogsRequest) (grpc.ServerStreamingClient[runnerv1.StreamWorkloadLogsResponse], error)
 	streamWorkloadLogsReq   *runnerv1.StreamWorkloadLogsRequest
 	streamWorkloadLogsCalls int
@@ -120,7 +125,13 @@ func (f *fakeRunnersClient) DeleteWorkload(ctx context.Context, in *runnersv1.De
 }
 
 func (f *fakeRunnersClient) GetWorkload(ctx context.Context, in *runnersv1.GetWorkloadRequest, opts ...grpc.CallOption) (*runnersv1.GetWorkloadResponse, error) {
-	return nil, status.Error(codes.Unimplemented, "GetWorkload not implemented")
+	f.getWorkloadCalls++
+	f.getWorkloadReq = in
+	f.getWorkloadMetadata, _ = metadata.FromOutgoingContext(ctx)
+	if f.getWorkload == nil {
+		return nil, status.Error(codes.Unimplemented, "GetWorkload not implemented")
+	}
+	return f.getWorkload(ctx, in)
 }
 
 func (f *fakeRunnersClient) ListWorkloadsByThread(ctx context.Context, in *runnersv1.ListWorkloadsByThreadRequest, opts ...grpc.CallOption) (*runnersv1.ListWorkloadsByThreadResponse, error) {
@@ -176,6 +187,46 @@ func newRunnersGatewayClient(t *testing.T, gateway *RunnersGateway) gatewayv1con
 	server := httptest.NewServer(mux)
 	t.Cleanup(server.Close)
 	return gatewayv1connect.NewRunnersGatewayClient(server.Client(), server.URL)
+}
+
+func assertMetadataValue(t *testing.T, md metadata.MD, key string, expected string) {
+	t.Helper()
+	got := md.Get(key)
+	if len(got) != 1 || got[0] != expected {
+		t.Fatalf("expected %s %q, got %#v", key, expected, got)
+	}
+}
+
+func TestRunnersGatewayGetWorkloadPropagatesIdentityMetadata(t *testing.T) {
+	client := &fakeRunnersClient{}
+	client.getWorkload = func(ctx context.Context, req *runnersv1.GetWorkloadRequest) (*runnersv1.GetWorkloadResponse, error) {
+		return &runnersv1.GetWorkloadResponse{Workload: &runnersv1.Workload{}}, nil
+	}
+	gateway := NewRunnersGateway(client)
+	resolved := identity.ResolvedIdentity{
+		IdentityID:   "identity-1",
+		IdentityType: identity.IdentityTypeUser,
+	}
+	ctx := metadata.AppendToOutgoingContext(
+		context.Background(),
+		identity.MetadataKeyIdentityID, "stale-identity",
+		identity.MetadataKeyIdentityType, string(identity.IdentityTypeRunner),
+	)
+	ctx = identity.WithIdentity(ctx, resolved)
+
+	_, err := gateway.GetWorkload(ctx, connect.NewRequest(&runnersv1.GetWorkloadRequest{Id: "workload-1"}))
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	if client.getWorkloadCalls != 1 {
+		t.Fatalf("expected GetWorkload to be called once, got %d", client.getWorkloadCalls)
+	}
+	if client.getWorkloadReq.GetId() != "workload-1" {
+		t.Fatalf("expected workload id to be forwarded")
+	}
+	assertMetadataValue(t, client.getWorkloadMetadata, identity.MetadataKeyIdentityID, resolved.IdentityID)
+	assertMetadataValue(t, client.getWorkloadMetadata, identity.MetadataKeyIdentityType, string(resolved.IdentityType))
 }
 
 func TestStreamWorkloadLogs_PassThrough(t *testing.T) {

--- a/internal/grpcclient/client.go
+++ b/internal/grpcclient/client.go
@@ -1,7 +1,9 @@
 package grpcclient
 
 import (
+	"context"
 	"fmt"
+	"net"
 	"strings"
 
 	"google.golang.org/grpc"
@@ -14,20 +16,43 @@ type Client[T any] struct {
 	client T
 }
 
-func New[T any](target string, factory func(grpc.ClientConnInterface) T) (*Client[T], error) {
+type Option func(*clientOptions)
+
+type clientOptions struct {
+	dialOptions []grpc.DialOption
+}
+
+func WithDialOption(option grpc.DialOption) Option {
+	return func(options *clientOptions) {
+		options.dialOptions = append(options.dialOptions, option)
+	}
+}
+
+func WithContextDialer(dialer func(context.Context, string) (net.Conn, error)) Option {
+	return WithDialOption(grpc.WithContextDialer(dialer))
+}
+
+func New[T any](target string, factory func(grpc.ClientConnInterface) T, opts ...Option) (*Client[T], error) {
 	if strings.TrimSpace(target) == "" {
 		return nil, fmt.Errorf("target is required")
 	}
 	if factory == nil {
 		return nil, fmt.Errorf("client factory is required")
 	}
+	options := clientOptions{}
+	for _, opt := range opts {
+		if opt != nil {
+			opt(&options)
+		}
+	}
 
-	conn, err := grpc.NewClient(
-		target,
+	dialOptions := []grpc.DialOption{
 		grpc.WithTransportCredentials(insecure.NewCredentials()),
 		grpc.WithChainUnaryInterceptor(identityUnaryClientInterceptor()),
 		grpc.WithChainStreamInterceptor(identityStreamClientInterceptor()),
-	)
+	}
+	dialOptions = append(dialOptions, options.dialOptions...)
+	conn, err := grpc.NewClient(target, dialOptions...)
 	if err != nil {
 		return nil, err
 	}

--- a/internal/grpcclient/client_test.go
+++ b/internal/grpcclient/client_test.go
@@ -1,0 +1,80 @@
+package grpcclient
+
+import (
+	"context"
+	"net"
+	"testing"
+
+	runnersv1 "github.com/agynio/gateway/gen/agynio/api/runners/v1"
+	"github.com/agynio/gateway/internal/identity"
+	"google.golang.org/grpc"
+	"google.golang.org/grpc/metadata"
+	"google.golang.org/grpc/test/bufconn"
+)
+
+const bufConnSize = 1024 * 1024
+
+type metadataCaptureRunnersServer struct {
+	runnersv1.UnimplementedRunnersServiceServer
+	metadata metadata.MD
+}
+
+func (s *metadataCaptureRunnersServer) GetWorkload(ctx context.Context, req *runnersv1.GetWorkloadRequest) (*runnersv1.GetWorkloadResponse, error) {
+	s.metadata, _ = metadata.FromIncomingContext(ctx)
+	return &runnersv1.GetWorkloadResponse{Workload: &runnersv1.Workload{}}, nil
+}
+
+func TestNewRunnersClientSendsSingleIdentityMetadataValue(t *testing.T) {
+	listener := bufconn.Listen(bufConnSize)
+	server := grpc.NewServer()
+	capture := &metadataCaptureRunnersServer{}
+	runnersv1.RegisterRunnersServiceServer(server, capture)
+	t.Cleanup(server.Stop)
+	go func() {
+		_ = server.Serve(listener)
+	}()
+
+	client, err := New(
+		"passthrough:///bufnet",
+		runnersv1.NewRunnersServiceClient,
+		WithContextDialer(func(context.Context, string) (net.Conn, error) {
+			return listener.Dial()
+		}),
+	)
+	if err != nil {
+		t.Fatalf("new runners client: %v", err)
+	}
+	t.Cleanup(func() { _ = client.Close() })
+
+	ctx := metadata.NewOutgoingContext(context.Background(), metadata.Pairs(
+		identity.MetadataKeyIdentityID, "stale-identity",
+		identity.MetadataKeyIdentityType, string(identity.IdentityTypeRunner),
+		identity.MetadataKeyWorkloadID, "stale-workload",
+	))
+	ctx = identity.WithIdentity(ctx, identity.ResolvedIdentity{
+		IdentityID:   "identity-1",
+		IdentityType: identity.IdentityTypeUser,
+	})
+
+	_, err = client.Service().GetWorkload(ctx, &runnersv1.GetWorkloadRequest{Id: "workload-1"})
+	if err != nil {
+		t.Fatalf("get workload: %v", err)
+	}
+
+	assertMetadataValues(t, capture.metadata, identity.MetadataKeyIdentityID, []string{"identity-1"})
+	assertMetadataValues(t, capture.metadata, identity.MetadataKeyIdentityType, []string{string(identity.IdentityTypeUser)})
+	assertMetadataValues(t, capture.metadata, identity.MetadataKeyWorkloadID, nil)
+}
+
+func assertMetadataValues(t *testing.T, md metadata.MD, key string, expected []string) {
+	t.Helper()
+	values := md.Get(key)
+	if len(values) != len(expected) {
+		t.Fatalf("expected %s values %v, got %v", key, expected, values)
+	}
+	for i, expectedValue := range expected {
+		if values[i] != expectedValue {
+			t.Fatalf("expected %s values %v, got %v", key, expected, values)
+		}
+	}
+}

--- a/internal/grpcclient/interceptors.go
+++ b/internal/grpcclient/interceptors.go
@@ -2,17 +2,9 @@ package grpcclient
 
 import (
 	"context"
-	"strings"
 
 	"github.com/agynio/gateway/internal/identity"
 	"google.golang.org/grpc"
-	"google.golang.org/grpc/metadata"
-)
-
-const (
-	identityIDMetadataKey   = "x-identity-id"
-	identityTypeMetadataKey = "x-identity-type"
-	workloadIDMetadataKey   = "x-workload-id"
 )
 
 func identityUnaryClientInterceptor() grpc.UnaryClientInterceptor {
@@ -30,20 +22,5 @@ func identityStreamClientInterceptor() grpc.StreamClientInterceptor {
 }
 
 func appendIdentityMetadata(ctx context.Context) context.Context {
-	resolved, ok := identity.IdentityFromContext(ctx)
-	if !ok {
-		return ctx
-	}
-
-	entries := []string{
-		identityIDMetadataKey,
-		resolved.IdentityID,
-		identityTypeMetadataKey,
-		string(resolved.IdentityType),
-	}
-	if strings.TrimSpace(resolved.WorkloadID) != "" {
-		entries = append(entries, workloadIDMetadataKey, resolved.WorkloadID)
-	}
-
-	return metadata.AppendToOutgoingContext(ctx, entries...)
+	return identity.AppendToOutgoingContext(ctx)
 }

--- a/internal/grpcclient/interceptors_test.go
+++ b/internal/grpcclient/interceptors_test.go
@@ -21,17 +21,17 @@ func TestAppendIdentityMetadataWithIdentity(t *testing.T) {
 		t.Fatalf("expected outgoing metadata")
 	}
 
-	identityIDs := md.Get(identityIDMetadataKey)
+	identityIDs := md.Get(identity.MetadataKeyIdentityID)
 	if len(identityIDs) != 1 || identityIDs[0] != "identity-123" {
 		t.Fatalf("expected identity id metadata, got %v", identityIDs)
 	}
 
-	identityTypes := md.Get(identityTypeMetadataKey)
+	identityTypes := md.Get(identity.MetadataKeyIdentityType)
 	if len(identityTypes) != 1 || identityTypes[0] != string(identity.IdentityTypeUser) {
 		t.Fatalf("expected identity type metadata, got %v", identityTypes)
 	}
 
-	workloadIDs := md.Get(workloadIDMetadataKey)
+	workloadIDs := md.Get(identity.MetadataKeyWorkloadID)
 	if len(workloadIDs) != 1 || workloadIDs[0] != "workload-123" {
 		t.Fatalf("expected workload id metadata, got %v", workloadIDs)
 	}
@@ -63,18 +63,51 @@ func TestAppendIdentityMetadataPreservesExisting(t *testing.T) {
 		t.Fatalf("expected existing metadata to be preserved, got %v", existing)
 	}
 
-	identityIDs := md.Get(identityIDMetadataKey)
+	identityIDs := md.Get(identity.MetadataKeyIdentityID)
 	if len(identityIDs) != 1 || identityIDs[0] != "identity-456" {
 		t.Fatalf("expected identity id metadata, got %v", identityIDs)
 	}
 
-	identityTypes := md.Get(identityTypeMetadataKey)
+	identityTypes := md.Get(identity.MetadataKeyIdentityType)
 	if len(identityTypes) != 1 || identityTypes[0] != string(identity.IdentityTypeAgent) {
 		t.Fatalf("expected identity type metadata, got %v", identityTypes)
 	}
 
-	workloadIDs := md.Get(workloadIDMetadataKey)
+	workloadIDs := md.Get(identity.MetadataKeyWorkloadID)
 	if len(workloadIDs) != 1 || workloadIDs[0] != "workload-456" {
 		t.Fatalf("expected workload id metadata, got %v", workloadIDs)
+	}
+}
+
+func TestAppendIdentityMetadataReplacesExisting(t *testing.T) {
+	ctx := metadata.NewOutgoingContext(context.Background(), metadata.Pairs(
+		identity.MetadataKeyIdentityID, "stale-identity",
+		identity.MetadataKeyIdentityType, string(identity.IdentityTypeRunner),
+		identity.MetadataKeyWorkloadID, "stale-workload",
+	))
+	ctx = identity.WithIdentity(ctx, identity.ResolvedIdentity{
+		IdentityID:   "identity-789",
+		IdentityType: identity.IdentityTypeUser,
+	})
+
+	ctx = appendIdentityMetadata(ctx)
+	md, ok := metadata.FromOutgoingContext(ctx)
+	if !ok {
+		t.Fatalf("expected outgoing metadata")
+	}
+
+	identityIDs := md.Get(identity.MetadataKeyIdentityID)
+	if len(identityIDs) != 1 || identityIDs[0] != "identity-789" {
+		t.Fatalf("expected one identity id metadata value, got %v", identityIDs)
+	}
+
+	identityTypes := md.Get(identity.MetadataKeyIdentityType)
+	if len(identityTypes) != 1 || identityTypes[0] != string(identity.IdentityTypeUser) {
+		t.Fatalf("expected one identity type metadata value, got %v", identityTypes)
+	}
+
+	workloadIDs := md.Get(identity.MetadataKeyWorkloadID)
+	if len(workloadIDs) != 0 {
+		t.Fatalf("expected workload metadata to be removed, got %v", workloadIDs)
 	}
 }

--- a/internal/identity/metadata.go
+++ b/internal/identity/metadata.go
@@ -22,16 +22,21 @@ func AppendToOutgoingContext(ctx context.Context) context.Context {
 		return ctx
 	}
 
-	entries := []string{
-		MetadataKeyIdentityID, resolved.IdentityID,
-		MetadataKeyIdentityType, string(resolved.IdentityType),
+	merged := metadata.MD{}
+	if existing, ok := metadata.FromOutgoingContext(ctx); ok {
+		for key, values := range existing {
+			merged[key] = append([]string(nil), values...)
+		}
 	}
+	merged.Set(MetadataKeyIdentityID, resolved.IdentityID)
+	merged.Set(MetadataKeyIdentityType, string(resolved.IdentityType))
 	workloadID := strings.TrimSpace(resolved.WorkloadID)
 	if workloadID != "" {
-		entries = append(entries, MetadataKeyWorkloadID, workloadID)
+		merged.Set(MetadataKeyWorkloadID, workloadID)
+	} else {
+		merged.Delete(MetadataKeyWorkloadID)
 	}
-
-	return metadata.AppendToOutgoingContext(ctx, entries...)
+	return metadata.NewOutgoingContext(ctx, merged)
 }
 
 func IdentityFromIncomingContext(ctx context.Context) (ResolvedIdentity, error) {

--- a/internal/identity/metadata_test.go
+++ b/internal/identity/metadata_test.go
@@ -40,6 +40,51 @@ func TestAppendToOutgoingContextMissingIdentity(t *testing.T) {
 	}
 }
 
+func TestAppendToOutgoingContextReplacesIdentityMetadata(t *testing.T) {
+	ctx := metadata.AppendToOutgoingContext(
+		context.Background(),
+		MetadataKeyIdentityID, "stale-identity",
+		MetadataKeyIdentityType, string(IdentityTypeRunner),
+		MetadataKeyWorkloadID, "stale-workload",
+	)
+	ctx = WithIdentity(ctx, ResolvedIdentity{
+		IdentityID:   "identity-123",
+		IdentityType: IdentityTypeUser,
+	})
+
+	ctx = AppendToOutgoingContext(ctx)
+	md, ok := metadata.FromOutgoingContext(ctx)
+	if !ok {
+		t.Fatalf("expected outgoing metadata")
+	}
+
+	assertMetadataValue(t, md, MetadataKeyIdentityID, "identity-123")
+	assertMetadataValue(t, md, MetadataKeyIdentityType, string(IdentityTypeUser))
+	if got := md.Get(MetadataKeyWorkloadID); len(got) != 0 {
+		t.Fatalf("expected workload metadata to be removed, got %v", got)
+	}
+}
+
+func TestAppendToOutgoingContextPreservesExistingMetadata(t *testing.T) {
+	ctx := metadata.AppendToOutgoingContext(context.Background(), "existing", "value")
+	ctx = WithIdentity(ctx, ResolvedIdentity{
+		IdentityID:   "identity-123",
+		IdentityType: IdentityTypeAgent,
+		WorkloadID:   "workload-123",
+	})
+
+	ctx = AppendToOutgoingContext(ctx)
+	md, ok := metadata.FromOutgoingContext(ctx)
+	if !ok {
+		t.Fatalf("expected outgoing metadata")
+	}
+
+	assertMetadataValue(t, md, "existing", "value")
+	assertMetadataValue(t, md, MetadataKeyIdentityID, "identity-123")
+	assertMetadataValue(t, md, MetadataKeyIdentityType, string(IdentityTypeAgent))
+	assertMetadataValue(t, md, MetadataKeyWorkloadID, "workload-123")
+}
+
 func TestIdentityFromIncomingContext(t *testing.T) {
 	ctx := metadata.NewIncomingContext(context.Background(), metadata.Pairs(
 		MetadataKeyIdentityID, "identity-777",


### PR DESCRIPTION
## Summary
- Fixes #185.
- Converts gateway's resolved in-process identity into outgoing gRPC metadata for downstream expose and runners proxy calls.
- Updates identity metadata propagation to replace stale identity headers instead of appending duplicates.
- Adds regression coverage for expose add and runners get workload metadata forwarding.

## Investigation
- `expose_test.go:90` path is agent CLI `agyn expose add` -> gateway `ExposeGateway.AddExposure` -> expose service -> runners `GetWorkload`.
- Gateway had the identity in `identity.ResolvedIdentity` on context, but did not attach it as outgoing gRPC metadata before calling expose.
- `idle_test.go` diagnostics has a separate direct e2e-context issue patched in agynio/e2e.

## Testing
- `buf generate buf.build/agynio/api --include-imports --path agynio/api/agents/v1 --path agynio/api/apps/v1 --path agynio/api/threads/v1 --path agynio/api/chat/v1 --path agynio/api/notifications/v1 --path agynio/api/files/v1 --path agynio/api/agent_state/v1 --path agynio/api/token_counting/v1 --path agynio/api/metering/v1 --path agynio/api/llm/v1 --path agynio/api/secrets/v1 --path agynio/api/identity/v1 --path agynio/api/tracing/v1 --path agynio/api/users/v1 --path agynio/api/organizations/v1 --path agynio/api/runners/v1 --path agynio/api/expose/v1 --path agynio/api/ziti_management/v1 --path agynio/api/gateway/v1`
- `go test ./...` (passed: 11 packages, failed: 0, skipped: 0)
- `go vet ./...` (lint passed with no errors)