### PR TITLE
fix: guard release publishing

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -15,9 +15,16 @@ env:
   CHART_REGISTRY: oci://ghcr.io/agynio/charts
 
 jobs:
+  guard:
+    name: Verify release tag
+    uses: agynio/.github/.github/workflows/release-tag-guard.yml@main
+    permissions:
+      contents: read
+
   image:
     name: Build and push container image
     runs-on: ubuntu-latest
+    needs: guard
 
     steps:
       - name: Checkout
@@ -85,20 +92,13 @@ jobs:
   helm:
     name: Package and push Helm chart
     runs-on: ubuntu-latest
+    needs:
+      - guard
+      - image
 
     steps:
       - name: Checkout
         uses: actions/checkout@v4
-
-      - name: Determine release version
-        id: version
-        run: |
-          if [[ "${GITHUB_REF_NAME}" != v*.*.* ]]; then
-            echo "Release tags must follow v*.*.*" >&2
-            exit 1
-          fi
-          VERSION="${GITHUB_REF_NAME#v}"
-          echo "version=${VERSION}" >> "$GITHUB_OUTPUT"
 
       - name: Set up Helm
         uses: azure/setup-helm@v4
@@ -120,10 +120,10 @@ jobs:
           mkdir -p dist
           helm package "$CHART_DIR" \
             --destination dist \
-            --version "${{ steps.version.outputs.version }}" \
-            --app-version "${{ steps.version.outputs.version }}"
+            --version "${{ needs.guard.outputs.version }}" \
+            --app-version "${{ needs.guard.outputs.version }}"
 
       - name: Push chart
         run: |
           CHART_NAME="$(basename "$CHART_DIR")"
-          helm push "dist/${CHART_NAME}-${{ steps.version.outputs.version }}.tgz" "$CHART_REGISTRY"
+          helm push "dist/${CHART_NAME}-${{ needs.guard.outputs.version }}.tgz" "$CHART_REGISTRY"


### PR DESCRIPTION
## Summary
- Adds a release guard job using the shared `agynio/.github` reusable workflow.
- Makes image publishing depend on the guard, so Docker login/build/push cannot run until the tag is verified.
- Makes Helm publishing depend on both the guard and image job, so chart publishing cannot run if image publishing fails.
- Reuses the guarded version output for chart packaging/push.

## Validation
- `actionlint`
- `helm dependency build charts/gateway`
- `helm lint charts/gateway --set gateway.platformBaseUrl=https://platform.example.com` (1 chart linted, 0 failed)
- `buf generate buf.build/agynio/api --include-imports --path agynio/api/agents/v1 --path agynio/api/apps/v1 --path agynio/api/threads/v1 --path agynio/api/chat/v1 --path agynio/api/notifications/v1 --path agynio/api/files/v1 --path agynio/api/agent_state/v1 --path agynio/api/token_counting/v1 --path agynio/api/metering/v1 --path agynio/api/llm/v1 --path agynio/api/secrets/v1 --path agynio/api/identity/v1 --path agynio/api/tracing/v1 --path agynio/api/users/v1 --path agynio/api/organizations/v1 --path agynio/api/runners/v1 --path agynio/api/expose/v1 --path agynio/api/egress/v1 --path agynio/api/ziti_management/v1 --path agynio/api/gateway/v1`
- `go test ./...` (all packages passed; no skipped tests reported)
- `go vet ./...`
- `/workspace/.github/scripts/validate-release-tag-guard.sh /workspace/gateway v0.22.11 main` failed as expected before any publish/login step would run.
- Local temporary tag `v999.999.998` on `origin/main` passed the same guard check.

Depends on shared guard PR: https://github.com/agynio/.github/pull/2
Related: agynio/.github#1