### PR TITLE
feat(auth): validate OIDC audience

### DIFF
--- a/charts/gateway/Chart.yaml
+++ b/charts/gateway/Chart.yaml
@@ -2,8 +2,8 @@ apiVersion: v2
 name: gateway
 description: Helm chart for deploying the agyn gateway service.
 type: application
-version: 0.4.1
-appVersion: 0.4.0
+version: 0.22.12
+appVersion: 0.22.12
 home: https://github.com/agynio/gateway
 sources:
   - https://github.com/agynio/gateway

--- a/charts/gateway/templates/_helpers.tpl
+++ b/charts/gateway/templates/_helpers.tpl
@@ -56,6 +56,11 @@
 {{- $env = append $env (dict "name" "OIDC_CLIENT_ID" "value" $oidcClientId) -}}
 {{- end -}}
 
+{{- $oidcAudience := trimAll " \n\t" (default "" .Values.gateway.oidcAudience) -}}
+{{- if $oidcAudience -}}
+{{- $env = append $env (dict "name" "OIDC_AUDIENCE" "value" $oidcAudience) -}}
+{{- end -}}
+
 {{- $clusterAdminToken := trimAll " \n\t" (default "" .Values.gateway.clusterAdminToken) -}}
 {{- if $clusterAdminToken -}}
 {{- $env = append $env (dict "name" "CLUSTER_ADMIN_TOKEN" "value" $clusterAdminToken) -}}

--- a/charts/gateway/values.yaml
+++ b/charts/gateway/values.yaml
@@ -168,5 +168,6 @@ gateway:
   egressRulesGrpcTarget: "egress-rules:50051"
   oidcIssuerUrl: ""
   oidcClientId: ""
+  oidcAudience: ""
   clusterAdminToken: ""
   clusterAdminIdentityId: ""

--- a/cmd/gateway/main.go
+++ b/cmd/gateway/main.go
@@ -97,7 +97,7 @@ func main() {
 		if config.OIDCIssuerURL == "" || config.OIDCClientID == "" {
 			log.Fatalf("both OIDC issuer URL and client ID are required when OIDC is enabled")
 		}
-		verifier, err := oidcauth.NewVerifier(ctx, config.OIDCIssuerURL, config.OIDCClientID)
+		verifier, err := oidcauth.NewVerifierWithAudience(ctx, config.OIDCIssuerURL, config.OIDCClientID, config.OIDCAudience)
 		if err != nil {
 			log.Fatalf("failed to create OIDC verifier: %v", err)
 		}

--- a/internal/oidcauth/verifier.go
+++ b/internal/oidcauth/verifier.go
@@ -19,6 +19,7 @@ type Claims struct {
 type Verifier struct {
 	issuer            string
 	clientID          string
+	audience          string
 	keySet            oidc.KeySet
 	userinfoEndpoint  string
 	supportedSignAlgs []string
@@ -26,6 +27,10 @@ type Verifier struct {
 }
 
 func NewVerifier(ctx context.Context, issuer, clientID string) (*Verifier, error) {
+	return NewVerifierWithAudience(ctx, issuer, clientID, "")
+}
+
+func NewVerifierWithAudience(ctx context.Context, issuer, clientID, audience string) (*Verifier, error) {
 	trimmedIssuer := strings.TrimSpace(issuer)
 	if trimmedIssuer == "" {
 		return nil, fmt.Errorf("issuer is required")
@@ -34,6 +39,7 @@ func NewVerifier(ctx context.Context, issuer, clientID string) (*Verifier, error
 	if trimmedClientID == "" {
 		return nil, fmt.Errorf("client id is required")
 	}
+	trimmedAudience := strings.TrimSpace(audience)
 
 	discovery, err := client.Discover(ctx, trimmedIssuer, httphelper.DefaultHTTPClient)
 	if err != nil {
@@ -48,6 +54,7 @@ func NewVerifier(ctx context.Context, issuer, clientID string) (*Verifier, error
 	return &Verifier{
 		issuer:           trimmedIssuer,
 		clientID:         trimmedClientID,
+		audience:         trimmedAudience,
 		keySet:           rp.NewRemoteKeySet(httphelper.DefaultHTTPClient, jwksURI),
 		userinfoEndpoint: userinfoEndpoint,
 		clockSkew:        time.Second,
@@ -86,6 +93,9 @@ func (v *Verifier) Verify(ctx context.Context, accessToken string) (Claims, erro
 	if err := oidc.CheckExpiration(&parsed, v.clockSkew); err != nil {
 		return Claims{}, err
 	}
+	if v.audience != "" && !containsAudience(parsed.Audience, v.audience) {
+		return Claims{}, fmt.Errorf("audience %q is required", v.audience)
+	}
 
 	subject := strings.TrimSpace(parsed.Subject)
 	if subject == "" {
@@ -95,4 +105,13 @@ func (v *Verifier) Verify(ctx context.Context, accessToken string) (Claims, erro
 	return Claims{
 		Subject: subject,
 	}, nil
+}
+
+func containsAudience(audiences oidc.Audience, required string) bool {
+	for _, audience := range audiences {
+		if audience == required {
+			return true
+		}
+	}
+	return false
 }

--- a/internal/oidcauth/verifier_test.go
+++ b/internal/oidcauth/verifier_test.go
@@ -56,6 +56,54 @@ func TestVerifierVerifyAcceptsResourceServerAudience(t *testing.T) {
 	}
 }
 
+func TestVerifierVerifyRequiresConfiguredAudience(t *testing.T) {
+	provider := oidctestutil.NewProvider(t)
+
+	verifier, err := NewVerifierWithAudience(context.Background(), provider.Issuer, provider.ClientID, "https://api.example.com")
+	if err != nil {
+		t.Fatalf("failed to create verifier: %v", err)
+	}
+
+	claims := oidc.NewAccessTokenClaims(
+		provider.Issuer,
+		provider.Subject,
+		[]string{"https://other.example.com"},
+		time.Now().Add(time.Hour),
+		"jwtid",
+		provider.ClientID,
+		time.Second,
+	)
+	token := provider.SignAccessToken(t, claims)
+
+	if _, err := verifier.Verify(context.Background(), token); err == nil {
+		t.Fatal("expected audience validation error")
+	}
+}
+
+func TestVerifierVerifyAcceptsConfiguredAudience(t *testing.T) {
+	provider := oidctestutil.NewProvider(t)
+
+	verifier, err := NewVerifierWithAudience(context.Background(), provider.Issuer, provider.ClientID, "https://api.example.com")
+	if err != nil {
+		t.Fatalf("failed to create verifier: %v", err)
+	}
+
+	claims := oidc.NewAccessTokenClaims(
+		provider.Issuer,
+		provider.Subject,
+		[]string{"https://api.example.com"},
+		time.Now().Add(time.Hour),
+		"jwtid",
+		provider.ClientID,
+		time.Second,
+	)
+	token := provider.SignAccessToken(t, claims)
+
+	if _, err := verifier.Verify(context.Background(), token); err != nil {
+		t.Fatalf("failed to verify token: %v", err)
+	}
+}
+
 func TestVerifierVerifyAcceptsEmptyAudience(t *testing.T) {
 	provider := oidctestutil.NewProvider(t)
 	verifier := newVerifier(t, provider)

--- a/internal/platform/config.go
+++ b/internal/platform/config.go
@@ -51,6 +51,7 @@ type Config struct {
 	ZitiManagementGRPCTarget string
 	OIDCIssuerURL            string
 	OIDCClientID             string
+	OIDCAudience             string
 	ClusterAdminToken        string
 	ClusterAdminIdentityID   string
 	UsersGRPCTarget          string
@@ -108,6 +109,7 @@ func LoadConfigFromEnv() (*Config, error) {
 		ZitiManagementGRPCTarget: envOrDefault("ZITI_MANAGEMENT_GRPC_TARGET", defaultZitiManagementGRPCTarget),
 		OIDCIssuerURL:            strings.TrimSpace(os.Getenv("OIDC_ISSUER_URL")),
 		OIDCClientID:             strings.TrimSpace(os.Getenv("OIDC_CLIENT_ID")),
+		OIDCAudience:             strings.TrimSpace(os.Getenv("OIDC_AUDIENCE")),
 		ClusterAdminToken:        clusterAdminToken,
 		ClusterAdminIdentityID:   clusterAdminIdentityID,
 		UsersGRPCTarget:          envOrDefault("USERS_GRPC_TARGET", defaultUsersGRPCTarget),

--- a/internal/platform/config_test.go
+++ b/internal/platform/config_test.go
@@ -28,6 +28,7 @@ func TestLoadConfigFromEnv(t *testing.T) {
 	t.Setenv("ZITI_MANAGEMENT_GRPC_TARGET", "ziti-management:50061")
 	t.Setenv("OIDC_ISSUER_URL", "https://issuer.example.com")
 	t.Setenv("OIDC_CLIENT_ID", "client-123")
+	t.Setenv("OIDC_AUDIENCE", "https://api.example.com")
 	t.Setenv("CLUSTER_ADMIN_TOKEN", "cluster-token")
 	t.Setenv("CLUSTER_ADMIN_IDENTITY_ID", "cluster-identity")
 
@@ -123,6 +124,9 @@ func TestLoadConfigFromEnv(t *testing.T) {
 	if got := cfg.OIDCClientID; got != "client-123" {
 		t.Fatalf("unexpected oidc client id: %s", got)
 	}
+	if got := cfg.OIDCAudience; got != "https://api.example.com" {
+		t.Fatalf("unexpected oidc audience: %s", got)
+	}
 
 	if got := cfg.ClusterAdminToken; got != "cluster-token" {
 		t.Fatalf("unexpected cluster admin token: %s", got)
@@ -170,6 +174,7 @@ func TestLoadConfigFromEnvAllDefaults(t *testing.T) {
 	t.Setenv("ZITI_MANAGEMENT_GRPC_TARGET", "")
 	t.Setenv("OIDC_ISSUER_URL", "")
 	t.Setenv("OIDC_CLIENT_ID", "")
+	t.Setenv("OIDC_AUDIENCE", "")
 	t.Setenv("CLUSTER_ADMIN_TOKEN", "")
 	t.Setenv("CLUSTER_ADMIN_IDENTITY_ID", "")
 
@@ -243,6 +248,9 @@ func TestLoadConfigFromEnvAllDefaults(t *testing.T) {
 	}
 	if cfg.OIDCClientID != "" {
 		t.Fatalf("unexpected oidc client id: %s", cfg.OIDCClientID)
+	}
+	if cfg.OIDCAudience != "" {
+		t.Fatalf("unexpected oidc audience: %s", cfg.OIDCAudience)
 	}
 	if cfg.ClusterAdminToken != "" {
 		t.Fatalf("unexpected cluster admin token: %s", cfg.ClusterAdminToken)


### PR DESCRIPTION
## Summary

Supports agynio/infrastructure#22 and agynio/infrastructure#23 by making the Logto API resource indicator functional instead of an inert chart value.

This PR wires the OIDC resource/audience through this repository's runtime/chart contract so the platform chart can pass `https://agyn.cloud` from the Logto workspace outputs.

## Validation

See the parent infrastructure PR for the full cross-repository validation summary.
