### PR TITLE
feat(gateway): forward groups and networks

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -54,6 +54,8 @@ jobs:
             --path agynio/api/runners/v1 \
             --path agynio/api/expose/v1 \
             --path agynio/api/egress/v1 \
+            --path agynio/api/groups/v1 \
+            --path agynio/api/networks/v1 \
             --path agynio/api/ziti_management/v1 \
             --path agynio/api/gateway/v1
 

--- a/charts/gateway/templates/_helpers.tpl
+++ b/charts/gateway/templates/_helpers.tpl
@@ -46,6 +46,12 @@
 {{- $egressRulesGrpcTarget := trimAll " \n\t" (default "" .Values.gateway.egressRulesGrpcTarget) -}}
 {{- $env = append $env (dict "name" "EGRESS_RULES_GRPC_TARGET" "value" $egressRulesGrpcTarget) -}}
 
+{{- $groupsGrpcTarget := trimAll " \n\t" (default "" .Values.gateway.groupsGrpcTarget) -}}
+{{- $env = append $env (dict "name" "GROUPS_GRPC_TARGET" "value" $groupsGrpcTarget) -}}
+
+{{- $networksGrpcTarget := trimAll " \n\t" (default "" .Values.gateway.networksGrpcTarget) -}}
+{{- $env = append $env (dict "name" "NETWORKS_GRPC_TARGET" "value" $networksGrpcTarget) -}}
+
 {{- $oidcIssuerUrl := trimAll " \n\t" (default "" .Values.gateway.oidcIssuerUrl) -}}
 {{- if $oidcIssuerUrl -}}
 {{- $env = append $env (dict "name" "OIDC_ISSUER_URL" "value" $oidcIssuerUrl) -}}

--- a/charts/gateway/values.yaml
+++ b/charts/gateway/values.yaml
@@ -166,6 +166,8 @@ gateway:
   runnersGrpcTarget: "runners:50051"
   exposeGrpcTarget: "expose:50051"
   egressRulesGrpcTarget: "egress-rules:50051"
+  groupsGrpcTarget: "groups:50051"
+  networksGrpcTarget: "networks:50051"
   oidcIssuerUrl: ""
   oidcClientId: ""
   clusterAdminToken: ""

--- a/cmd/gateway/main.go
+++ b/cmd/gateway/main.go
@@ -26,8 +26,10 @@ import (
 	exposev1 "github.com/agynio/gateway/gen/agynio/api/expose/v1"
 	filesv1 "github.com/agynio/gateway/gen/agynio/api/files/v1"
 	"github.com/agynio/gateway/gen/agynio/api/gateway/v1/gatewayv1connect"
+	groupsv1 "github.com/agynio/gateway/gen/agynio/api/groups/v1"
 	llmv1 "github.com/agynio/gateway/gen/agynio/api/llm/v1"
 	meteringv1 "github.com/agynio/gateway/gen/agynio/api/metering/v1"
+	networksv1 "github.com/agynio/gateway/gen/agynio/api/networks/v1"
 	notificationsv1 "github.com/agynio/gateway/gen/agynio/api/notifications/v1"
 	organizationsv1 "github.com/agynio/gateway/gen/agynio/api/organizations/v1"
 	runnersv1 "github.com/agynio/gateway/gen/agynio/api/runners/v1"
@@ -136,6 +138,8 @@ func main() {
 	tracingClient := mustClient(config.TracingGRPCTarget, "tracing", tracingv1.NewTracingServiceClient, &cleanup)
 	exposeClient := mustClient(config.ExposeGRPCTarget, "expose", exposev1.NewExposeServiceClient, &cleanup)
 	egressRulesClient := mustClient(config.EgressRulesGRPCTarget, "egress rules", egressv1.NewEgressRulesServiceClient, &cleanup)
+	groupsClient := mustClient(config.GroupsGRPCTarget, "groups", groupsv1.NewGroupsServiceClient, &cleanup)
+	networksClient := mustClient(config.NetworksGRPCTarget, "networks", networksv1.NewNetworksServiceClient, &cleanup)
 
 	gatewayHandler := gateway.New(
 		agentsClient,
@@ -157,6 +161,8 @@ func main() {
 	meteringGateway := gateway.NewMeteringGateway(meteringClient)
 	exposeGateway := gateway.NewExposeGateway(exposeClient)
 	egressRulesGateway := gateway.NewEgressRulesGateway(egressRulesClient)
+	groupsGateway := gateway.NewGroupsGateway(groupsClient)
+	networksGateway := gateway.NewNetworksGateway(networksClient)
 
 	interceptors := []connect.Interceptor{
 		gateway.NewRecoveryInterceptor(),
@@ -196,6 +202,8 @@ func main() {
 	registerConnect(gatewayv1connect.NewRunnersGatewayHandler(runnersGateway, handlerOptions))
 	registerConnect(gatewayv1connect.NewExposeGatewayHandler(exposeGateway, handlerOptions))
 	registerConnect(gatewayv1connect.NewEgressRulesGatewayHandler(egressRulesGateway, handlerOptions))
+	registerConnect(gatewayv1connect.NewGroupsGatewayHandler(groupsGateway, handlerOptions))
+	registerConnect(gatewayv1connect.NewNetworksGatewayHandler(networksGateway, handlerOptions))
 
 	corsMiddleware := cors.New(cors.Options{
 		AllowedOrigins: []string{"*"},

--- a/internal/gateway/groups.go
+++ b/internal/gateway/groups.go
@@ -1,0 +1,88 @@
+package gateway
+
+import (
+	"context"
+
+	"connectrpc.com/connect"
+	groupsv1 "github.com/agynio/gateway/gen/agynio/api/groups/v1"
+)
+
+type GroupsGateway struct {
+	groups groupsv1.GroupsServiceClient
+}
+
+func NewGroupsGateway(groups groupsv1.GroupsServiceClient) *GroupsGateway {
+	return &GroupsGateway{groups: groups}
+}
+
+func (g *GroupsGateway) CreateGroup(ctx context.Context, req *connect.Request[groupsv1.CreateGroupRequest]) (*connect.Response[groupsv1.CreateGroupResponse], error) {
+	resp, err := g.groups.CreateGroup(downstreamContext(ctx), req.Msg)
+	if err != nil {
+		return nil, toConnectError(err)
+	}
+	return connect.NewResponse(resp), nil
+}
+
+func (g *GroupsGateway) GetGroup(ctx context.Context, req *connect.Request[groupsv1.GetGroupRequest]) (*connect.Response[groupsv1.GetGroupResponse], error) {
+	resp, err := g.groups.GetGroup(downstreamContext(ctx), req.Msg)
+	if err != nil {
+		return nil, toConnectError(err)
+	}
+	return connect.NewResponse(resp), nil
+}
+
+func (g *GroupsGateway) ListGroups(ctx context.Context, req *connect.Request[groupsv1.ListGroupsRequest]) (*connect.Response[groupsv1.ListGroupsResponse], error) {
+	resp, err := g.groups.ListGroups(downstreamContext(ctx), req.Msg)
+	if err != nil {
+		return nil, toConnectError(err)
+	}
+	return connect.NewResponse(resp), nil
+}
+
+func (g *GroupsGateway) UpdateGroup(ctx context.Context, req *connect.Request[groupsv1.UpdateGroupRequest]) (*connect.Response[groupsv1.UpdateGroupResponse], error) {
+	resp, err := g.groups.UpdateGroup(downstreamContext(ctx), req.Msg)
+	if err != nil {
+		return nil, toConnectError(err)
+	}
+	return connect.NewResponse(resp), nil
+}
+
+func (g *GroupsGateway) DeleteGroup(ctx context.Context, req *connect.Request[groupsv1.DeleteGroupRequest]) (*connect.Response[groupsv1.DeleteGroupResponse], error) {
+	resp, err := g.groups.DeleteGroup(downstreamContext(ctx), req.Msg)
+	if err != nil {
+		return nil, toConnectError(err)
+	}
+	return connect.NewResponse(resp), nil
+}
+
+func (g *GroupsGateway) AddMember(ctx context.Context, req *connect.Request[groupsv1.AddMemberRequest]) (*connect.Response[groupsv1.AddMemberResponse], error) {
+	resp, err := g.groups.AddMember(downstreamContext(ctx), req.Msg)
+	if err != nil {
+		return nil, toConnectError(err)
+	}
+	return connect.NewResponse(resp), nil
+}
+
+func (g *GroupsGateway) RemoveMember(ctx context.Context, req *connect.Request[groupsv1.RemoveMemberRequest]) (*connect.Response[groupsv1.RemoveMemberResponse], error) {
+	resp, err := g.groups.RemoveMember(downstreamContext(ctx), req.Msg)
+	if err != nil {
+		return nil, toConnectError(err)
+	}
+	return connect.NewResponse(resp), nil
+}
+
+func (g *GroupsGateway) ListMembers(ctx context.Context, req *connect.Request[groupsv1.ListMembersRequest]) (*connect.Response[groupsv1.ListMembersResponse], error) {
+	resp, err := g.groups.ListMembers(downstreamContext(ctx), req.Msg)
+	if err != nil {
+		return nil, toConnectError(err)
+	}
+	return connect.NewResponse(resp), nil
+}
+
+func (g *GroupsGateway) ListMemberGroups(ctx context.Context, req *connect.Request[groupsv1.ListMemberGroupsRequest]) (*connect.Response[groupsv1.ListMemberGroupsResponse], error) {
+	resp, err := g.groups.ListMemberGroups(downstreamContext(ctx), req.Msg)
+	if err != nil {
+		return nil, toConnectError(err)
+	}
+	return connect.NewResponse(resp), nil
+}

--- a/internal/gateway/groups_test.go
+++ b/internal/gateway/groups_test.go
@@ -1,0 +1,108 @@
+package gateway
+
+import (
+	"context"
+	"testing"
+
+	"connectrpc.com/connect"
+	groupsv1 "github.com/agynio/gateway/gen/agynio/api/groups/v1"
+	"github.com/agynio/gateway/internal/identity"
+	"google.golang.org/grpc"
+	"google.golang.org/grpc/codes"
+	"google.golang.org/grpc/metadata"
+	"google.golang.org/grpc/status"
+)
+
+type fakeGroupsClient struct {
+	createReq       *groupsv1.CreateGroupRequest
+	createMetadata  metadata.MD
+	createErr       error
+	getReq          *groupsv1.GetGroupRequest
+	listReq         *groupsv1.ListGroupsRequest
+	updateReq       *groupsv1.UpdateGroupRequest
+	deleteReq       *groupsv1.DeleteGroupRequest
+	addReq          *groupsv1.AddMemberRequest
+	removeReq       *groupsv1.RemoveMemberRequest
+	membersReq      *groupsv1.ListMembersRequest
+	memberGroupsReq *groupsv1.ListMemberGroupsRequest
+}
+
+func (f *fakeGroupsClient) CreateGroup(ctx context.Context, req *groupsv1.CreateGroupRequest, _ ...grpc.CallOption) (*groupsv1.CreateGroupResponse, error) {
+	f.createReq = req
+	f.createMetadata, _ = metadata.FromOutgoingContext(ctx)
+	if f.createErr != nil {
+		return nil, f.createErr
+	}
+	return &groupsv1.CreateGroupResponse{}, nil
+}
+func (f *fakeGroupsClient) GetGroup(_ context.Context, req *groupsv1.GetGroupRequest, _ ...grpc.CallOption) (*groupsv1.GetGroupResponse, error) {
+	f.getReq = req
+	return &groupsv1.GetGroupResponse{}, nil
+}
+func (f *fakeGroupsClient) ListGroups(_ context.Context, req *groupsv1.ListGroupsRequest, _ ...grpc.CallOption) (*groupsv1.ListGroupsResponse, error) {
+	f.listReq = req
+	return &groupsv1.ListGroupsResponse{}, nil
+}
+func (f *fakeGroupsClient) UpdateGroup(_ context.Context, req *groupsv1.UpdateGroupRequest, _ ...grpc.CallOption) (*groupsv1.UpdateGroupResponse, error) {
+	f.updateReq = req
+	return &groupsv1.UpdateGroupResponse{}, nil
+}
+func (f *fakeGroupsClient) DeleteGroup(_ context.Context, req *groupsv1.DeleteGroupRequest, _ ...grpc.CallOption) (*groupsv1.DeleteGroupResponse, error) {
+	f.deleteReq = req
+	return &groupsv1.DeleteGroupResponse{}, nil
+}
+func (f *fakeGroupsClient) AddMember(_ context.Context, req *groupsv1.AddMemberRequest, _ ...grpc.CallOption) (*groupsv1.AddMemberResponse, error) {
+	f.addReq = req
+	return &groupsv1.AddMemberResponse{}, nil
+}
+func (f *fakeGroupsClient) RemoveMember(_ context.Context, req *groupsv1.RemoveMemberRequest, _ ...grpc.CallOption) (*groupsv1.RemoveMemberResponse, error) {
+	f.removeReq = req
+	return &groupsv1.RemoveMemberResponse{}, nil
+}
+func (f *fakeGroupsClient) ListMembers(_ context.Context, req *groupsv1.ListMembersRequest, _ ...grpc.CallOption) (*groupsv1.ListMembersResponse, error) {
+	f.membersReq = req
+	return &groupsv1.ListMembersResponse{}, nil
+}
+func (f *fakeGroupsClient) ListMemberGroups(_ context.Context, req *groupsv1.ListMemberGroupsRequest, _ ...grpc.CallOption) (*groupsv1.ListMemberGroupsResponse, error) {
+	f.memberGroupsReq = req
+	return &groupsv1.ListMemberGroupsResponse{}, nil
+}
+func (f *fakeGroupsClient) ListMemberGroupsBatch(context.Context, *groupsv1.ListMemberGroupsBatchRequest, ...grpc.CallOption) (*groupsv1.ListMemberGroupsBatchResponse, error) {
+	return &groupsv1.ListMemberGroupsBatchResponse{}, nil
+}
+
+func TestGroupsGatewayForwardsAndPropagatesMetadata(t *testing.T) {
+	client := &fakeGroupsClient{}
+	gateway := NewGroupsGateway(client)
+	resolved := identity.ResolvedIdentity{IdentityID: "user-1", IdentityType: identity.IdentityTypeUser}
+	ctx := identity.WithIdentity(context.Background(), resolved)
+
+	if _, err := gateway.CreateGroup(ctx, connect.NewRequest(&groupsv1.CreateGroupRequest{OrganizationId: "org-1", Name: "admins"})); err != nil {
+		t.Fatalf("create group: %v", err)
+	}
+	if client.createReq.GetName() != "admins" {
+		t.Fatalf("expected create request to be forwarded")
+	}
+	assertMetadataValue(t, client.createMetadata, identity.MetadataKeyIdentityID, resolved.IdentityID)
+
+	_, _ = gateway.GetGroup(context.Background(), connect.NewRequest(&groupsv1.GetGroupRequest{Id: "group-1"}))
+	_, _ = gateway.ListGroups(context.Background(), connect.NewRequest(&groupsv1.ListGroupsRequest{OrganizationId: "org-1"}))
+	_, _ = gateway.UpdateGroup(context.Background(), connect.NewRequest(&groupsv1.UpdateGroupRequest{Id: "group-2"}))
+	_, _ = gateway.DeleteGroup(context.Background(), connect.NewRequest(&groupsv1.DeleteGroupRequest{Id: "group-3"}))
+	_, _ = gateway.AddMember(context.Background(), connect.NewRequest(&groupsv1.AddMemberRequest{GroupId: "group-4", MemberId: "user-2"}))
+	_, _ = gateway.RemoveMember(context.Background(), connect.NewRequest(&groupsv1.RemoveMemberRequest{GroupId: "group-5", MemberId: "user-3"}))
+	_, _ = gateway.ListMembers(context.Background(), connect.NewRequest(&groupsv1.ListMembersRequest{GroupId: "group-6"}))
+	_, _ = gateway.ListMemberGroups(context.Background(), connect.NewRequest(&groupsv1.ListMemberGroupsRequest{OrganizationId: "org-1", MemberId: "user-4"}))
+
+	if client.getReq.GetId() != "group-1" || client.listReq.GetOrganizationId() != "org-1" || client.updateReq.GetId() != "group-2" || client.deleteReq.GetId() != "group-3" || client.addReq.GetGroupId() != "group-4" || client.removeReq.GetGroupId() != "group-5" || client.membersReq.GetGroupId() != "group-6" || client.memberGroupsReq.GetMemberId() != "user-4" {
+		t.Fatalf("expected public group methods to be forwarded")
+	}
+}
+
+func TestGroupsGatewayMapsErrors(t *testing.T) {
+	client := &fakeGroupsClient{createErr: status.Error(codes.PermissionDenied, "nope")}
+	_, err := NewGroupsGateway(client).CreateGroup(context.Background(), connect.NewRequest(&groupsv1.CreateGroupRequest{}))
+	if connect.CodeOf(err) != connect.CodePermissionDenied {
+		t.Fatalf("expected permission denied, got %v", err)
+	}
+}

--- a/internal/gateway/networks.go
+++ b/internal/gateway/networks.go
@@ -1,0 +1,152 @@
+package gateway
+
+import (
+	"context"
+
+	"connectrpc.com/connect"
+	networksv1 "github.com/agynio/gateway/gen/agynio/api/networks/v1"
+)
+
+type NetworksGateway struct {
+	networks networksv1.NetworksServiceClient
+}
+
+func NewNetworksGateway(networks networksv1.NetworksServiceClient) *NetworksGateway {
+	return &NetworksGateway{networks: networks}
+}
+
+func (g *NetworksGateway) CreateNetwork(ctx context.Context, req *connect.Request[networksv1.CreateNetworkRequest]) (*connect.Response[networksv1.CreateNetworkResponse], error) {
+	resp, err := g.networks.CreateNetwork(downstreamContext(ctx), req.Msg)
+	if err != nil {
+		return nil, toConnectError(err)
+	}
+	return connect.NewResponse(resp), nil
+}
+
+func (g *NetworksGateway) GetNetwork(ctx context.Context, req *connect.Request[networksv1.GetNetworkRequest]) (*connect.Response[networksv1.GetNetworkResponse], error) {
+	resp, err := g.networks.GetNetwork(downstreamContext(ctx), req.Msg)
+	if err != nil {
+		return nil, toConnectError(err)
+	}
+	return connect.NewResponse(resp), nil
+}
+
+func (g *NetworksGateway) ListNetworks(ctx context.Context, req *connect.Request[networksv1.ListNetworksRequest]) (*connect.Response[networksv1.ListNetworksResponse], error) {
+	resp, err := g.networks.ListNetworks(downstreamContext(ctx), req.Msg)
+	if err != nil {
+		return nil, toConnectError(err)
+	}
+	return connect.NewResponse(resp), nil
+}
+
+func (g *NetworksGateway) UpdateNetwork(ctx context.Context, req *connect.Request[networksv1.UpdateNetworkRequest]) (*connect.Response[networksv1.UpdateNetworkResponse], error) {
+	resp, err := g.networks.UpdateNetwork(downstreamContext(ctx), req.Msg)
+	if err != nil {
+		return nil, toConnectError(err)
+	}
+	return connect.NewResponse(resp), nil
+}
+
+func (g *NetworksGateway) DeleteNetwork(ctx context.Context, req *connect.Request[networksv1.DeleteNetworkRequest]) (*connect.Response[networksv1.DeleteNetworkResponse], error) {
+	resp, err := g.networks.DeleteNetwork(downstreamContext(ctx), req.Msg)
+	if err != nil {
+		return nil, toConnectError(err)
+	}
+	return connect.NewResponse(resp), nil
+}
+
+func (g *NetworksGateway) CreateTunnelCredential(ctx context.Context, req *connect.Request[networksv1.CreateTunnelCredentialRequest]) (*connect.Response[networksv1.CreateTunnelCredentialResponse], error) {
+	resp, err := g.networks.CreateTunnelCredential(downstreamContext(ctx), req.Msg)
+	if err != nil {
+		return nil, toConnectError(err)
+	}
+	return connect.NewResponse(resp), nil
+}
+
+func (g *NetworksGateway) GetTunnelCredential(ctx context.Context, req *connect.Request[networksv1.GetTunnelCredentialRequest]) (*connect.Response[networksv1.GetTunnelCredentialResponse], error) {
+	resp, err := g.networks.GetTunnelCredential(downstreamContext(ctx), req.Msg)
+	if err != nil {
+		return nil, toConnectError(err)
+	}
+	return connect.NewResponse(resp), nil
+}
+
+func (g *NetworksGateway) ListTunnelCredentials(ctx context.Context, req *connect.Request[networksv1.ListTunnelCredentialsRequest]) (*connect.Response[networksv1.ListTunnelCredentialsResponse], error) {
+	resp, err := g.networks.ListTunnelCredentials(downstreamContext(ctx), req.Msg)
+	if err != nil {
+		return nil, toConnectError(err)
+	}
+	return connect.NewResponse(resp), nil
+}
+
+func (g *NetworksGateway) DeleteTunnelCredential(ctx context.Context, req *connect.Request[networksv1.DeleteTunnelCredentialRequest]) (*connect.Response[networksv1.DeleteTunnelCredentialResponse], error) {
+	resp, err := g.networks.DeleteTunnelCredential(downstreamContext(ctx), req.Msg)
+	if err != nil {
+		return nil, toConnectError(err)
+	}
+	return connect.NewResponse(resp), nil
+}
+
+func (g *NetworksGateway) CreatePrivateResource(ctx context.Context, req *connect.Request[networksv1.CreatePrivateResourceRequest]) (*connect.Response[networksv1.CreatePrivateResourceResponse], error) {
+	resp, err := g.networks.CreatePrivateResource(downstreamContext(ctx), req.Msg)
+	if err != nil {
+		return nil, toConnectError(err)
+	}
+	return connect.NewResponse(resp), nil
+}
+
+func (g *NetworksGateway) GetPrivateResource(ctx context.Context, req *connect.Request[networksv1.GetPrivateResourceRequest]) (*connect.Response[networksv1.GetPrivateResourceResponse], error) {
+	resp, err := g.networks.GetPrivateResource(downstreamContext(ctx), req.Msg)
+	if err != nil {
+		return nil, toConnectError(err)
+	}
+	return connect.NewResponse(resp), nil
+}
+
+func (g *NetworksGateway) ListPrivateResources(ctx context.Context, req *connect.Request[networksv1.ListPrivateResourcesRequest]) (*connect.Response[networksv1.ListPrivateResourcesResponse], error) {
+	resp, err := g.networks.ListPrivateResources(downstreamContext(ctx), req.Msg)
+	if err != nil {
+		return nil, toConnectError(err)
+	}
+	return connect.NewResponse(resp), nil
+}
+
+func (g *NetworksGateway) UpdatePrivateResource(ctx context.Context, req *connect.Request[networksv1.UpdatePrivateResourceRequest]) (*connect.Response[networksv1.UpdatePrivateResourceResponse], error) {
+	resp, err := g.networks.UpdatePrivateResource(downstreamContext(ctx), req.Msg)
+	if err != nil {
+		return nil, toConnectError(err)
+	}
+	return connect.NewResponse(resp), nil
+}
+
+func (g *NetworksGateway) DeletePrivateResource(ctx context.Context, req *connect.Request[networksv1.DeletePrivateResourceRequest]) (*connect.Response[networksv1.DeletePrivateResourceResponse], error) {
+	resp, err := g.networks.DeletePrivateResource(downstreamContext(ctx), req.Msg)
+	if err != nil {
+		return nil, toConnectError(err)
+	}
+	return connect.NewResponse(resp), nil
+}
+
+func (g *NetworksGateway) CreatePrivateResourceAccess(ctx context.Context, req *connect.Request[networksv1.CreatePrivateResourceAccessRequest]) (*connect.Response[networksv1.CreatePrivateResourceAccessResponse], error) {
+	resp, err := g.networks.CreatePrivateResourceAccess(downstreamContext(ctx), req.Msg)
+	if err != nil {
+		return nil, toConnectError(err)
+	}
+	return connect.NewResponse(resp), nil
+}
+
+func (g *NetworksGateway) DeletePrivateResourceAccess(ctx context.Context, req *connect.Request[networksv1.DeletePrivateResourceAccessRequest]) (*connect.Response[networksv1.DeletePrivateResourceAccessResponse], error) {
+	resp, err := g.networks.DeletePrivateResourceAccess(downstreamContext(ctx), req.Msg)
+	if err != nil {
+		return nil, toConnectError(err)
+	}
+	return connect.NewResponse(resp), nil
+}
+
+func (g *NetworksGateway) ListPrivateResourceAccess(ctx context.Context, req *connect.Request[networksv1.ListPrivateResourceAccessRequest]) (*connect.Response[networksv1.ListPrivateResourceAccessResponse], error) {
+	resp, err := g.networks.ListPrivateResourceAccess(downstreamContext(ctx), req.Msg)
+	if err != nil {
+		return nil, toConnectError(err)
+	}
+	return connect.NewResponse(resp), nil
+}

--- a/internal/gateway/networks_test.go
+++ b/internal/gateway/networks_test.go
@@ -1,0 +1,155 @@
+package gateway
+
+import (
+	"context"
+	"testing"
+
+	"connectrpc.com/connect"
+	networksv1 "github.com/agynio/gateway/gen/agynio/api/networks/v1"
+	"github.com/agynio/gateway/internal/identity"
+	"google.golang.org/grpc"
+	"google.golang.org/grpc/codes"
+	"google.golang.org/grpc/metadata"
+	"google.golang.org/grpc/status"
+)
+
+type fakeNetworksClient struct {
+	createNetworkReq      *networksv1.CreateNetworkRequest
+	createNetworkMetadata metadata.MD
+	createNetworkErr      error
+	getNetworkReq         *networksv1.GetNetworkRequest
+	listNetworksReq       *networksv1.ListNetworksRequest
+	updateNetworkReq      *networksv1.UpdateNetworkRequest
+	deleteNetworkReq      *networksv1.DeleteNetworkRequest
+	createTunnelReq       *networksv1.CreateTunnelCredentialRequest
+	getTunnelReq          *networksv1.GetTunnelCredentialRequest
+	listTunnelsReq        *networksv1.ListTunnelCredentialsRequest
+	deleteTunnelReq       *networksv1.DeleteTunnelCredentialRequest
+	createResourceReq     *networksv1.CreatePrivateResourceRequest
+	getResourceReq        *networksv1.GetPrivateResourceRequest
+	listResourcesReq      *networksv1.ListPrivateResourcesRequest
+	updateResourceReq     *networksv1.UpdatePrivateResourceRequest
+	deleteResourceReq     *networksv1.DeletePrivateResourceRequest
+	createAccessReq       *networksv1.CreatePrivateResourceAccessRequest
+	deleteAccessReq       *networksv1.DeletePrivateResourceAccessRequest
+	listAccessReq         *networksv1.ListPrivateResourceAccessRequest
+}
+
+func (f *fakeNetworksClient) CreateNetwork(ctx context.Context, req *networksv1.CreateNetworkRequest, _ ...grpc.CallOption) (*networksv1.CreateNetworkResponse, error) {
+	f.createNetworkReq = req
+	f.createNetworkMetadata, _ = metadata.FromOutgoingContext(ctx)
+	if f.createNetworkErr != nil {
+		return nil, f.createNetworkErr
+	}
+	return &networksv1.CreateNetworkResponse{}, nil
+}
+func (f *fakeNetworksClient) GetNetwork(_ context.Context, req *networksv1.GetNetworkRequest, _ ...grpc.CallOption) (*networksv1.GetNetworkResponse, error) {
+	f.getNetworkReq = req
+	return &networksv1.GetNetworkResponse{}, nil
+}
+func (f *fakeNetworksClient) ListNetworks(_ context.Context, req *networksv1.ListNetworksRequest, _ ...grpc.CallOption) (*networksv1.ListNetworksResponse, error) {
+	f.listNetworksReq = req
+	return &networksv1.ListNetworksResponse{}, nil
+}
+func (f *fakeNetworksClient) UpdateNetwork(_ context.Context, req *networksv1.UpdateNetworkRequest, _ ...grpc.CallOption) (*networksv1.UpdateNetworkResponse, error) {
+	f.updateNetworkReq = req
+	return &networksv1.UpdateNetworkResponse{}, nil
+}
+func (f *fakeNetworksClient) DeleteNetwork(_ context.Context, req *networksv1.DeleteNetworkRequest, _ ...grpc.CallOption) (*networksv1.DeleteNetworkResponse, error) {
+	f.deleteNetworkReq = req
+	return &networksv1.DeleteNetworkResponse{}, nil
+}
+func (f *fakeNetworksClient) CreateTunnelCredential(_ context.Context, req *networksv1.CreateTunnelCredentialRequest, _ ...grpc.CallOption) (*networksv1.CreateTunnelCredentialResponse, error) {
+	f.createTunnelReq = req
+	return &networksv1.CreateTunnelCredentialResponse{}, nil
+}
+func (f *fakeNetworksClient) GetTunnelCredential(_ context.Context, req *networksv1.GetTunnelCredentialRequest, _ ...grpc.CallOption) (*networksv1.GetTunnelCredentialResponse, error) {
+	f.getTunnelReq = req
+	return &networksv1.GetTunnelCredentialResponse{}, nil
+}
+func (f *fakeNetworksClient) ListTunnelCredentials(_ context.Context, req *networksv1.ListTunnelCredentialsRequest, _ ...grpc.CallOption) (*networksv1.ListTunnelCredentialsResponse, error) {
+	f.listTunnelsReq = req
+	return &networksv1.ListTunnelCredentialsResponse{}, nil
+}
+func (f *fakeNetworksClient) DeleteTunnelCredential(_ context.Context, req *networksv1.DeleteTunnelCredentialRequest, _ ...grpc.CallOption) (*networksv1.DeleteTunnelCredentialResponse, error) {
+	f.deleteTunnelReq = req
+	return &networksv1.DeleteTunnelCredentialResponse{}, nil
+}
+func (f *fakeNetworksClient) CreatePrivateResource(_ context.Context, req *networksv1.CreatePrivateResourceRequest, _ ...grpc.CallOption) (*networksv1.CreatePrivateResourceResponse, error) {
+	f.createResourceReq = req
+	return &networksv1.CreatePrivateResourceResponse{}, nil
+}
+func (f *fakeNetworksClient) GetPrivateResource(_ context.Context, req *networksv1.GetPrivateResourceRequest, _ ...grpc.CallOption) (*networksv1.GetPrivateResourceResponse, error) {
+	f.getResourceReq = req
+	return &networksv1.GetPrivateResourceResponse{}, nil
+}
+func (f *fakeNetworksClient) ListPrivateResources(_ context.Context, req *networksv1.ListPrivateResourcesRequest, _ ...grpc.CallOption) (*networksv1.ListPrivateResourcesResponse, error) {
+	f.listResourcesReq = req
+	return &networksv1.ListPrivateResourcesResponse{}, nil
+}
+func (f *fakeNetworksClient) UpdatePrivateResource(_ context.Context, req *networksv1.UpdatePrivateResourceRequest, _ ...grpc.CallOption) (*networksv1.UpdatePrivateResourceResponse, error) {
+	f.updateResourceReq = req
+	return &networksv1.UpdatePrivateResourceResponse{}, nil
+}
+func (f *fakeNetworksClient) DeletePrivateResource(_ context.Context, req *networksv1.DeletePrivateResourceRequest, _ ...grpc.CallOption) (*networksv1.DeletePrivateResourceResponse, error) {
+	f.deleteResourceReq = req
+	return &networksv1.DeletePrivateResourceResponse{}, nil
+}
+func (f *fakeNetworksClient) CreatePrivateResourceAccess(_ context.Context, req *networksv1.CreatePrivateResourceAccessRequest, _ ...grpc.CallOption) (*networksv1.CreatePrivateResourceAccessResponse, error) {
+	f.createAccessReq = req
+	return &networksv1.CreatePrivateResourceAccessResponse{}, nil
+}
+func (f *fakeNetworksClient) DeletePrivateResourceAccess(_ context.Context, req *networksv1.DeletePrivateResourceAccessRequest, _ ...grpc.CallOption) (*networksv1.DeletePrivateResourceAccessResponse, error) {
+	f.deleteAccessReq = req
+	return &networksv1.DeletePrivateResourceAccessResponse{}, nil
+}
+func (f *fakeNetworksClient) ListPrivateResourceAccess(_ context.Context, req *networksv1.ListPrivateResourceAccessRequest, _ ...grpc.CallOption) (*networksv1.ListPrivateResourceAccessResponse, error) {
+	f.listAccessReq = req
+	return &networksv1.ListPrivateResourceAccessResponse{}, nil
+}
+
+func TestNetworksGatewayForwardsAndPropagatesMetadata(t *testing.T) {
+	client := &fakeNetworksClient{}
+	gateway := NewNetworksGateway(client)
+	resolved := identity.ResolvedIdentity{IdentityID: "user-1", IdentityType: identity.IdentityTypeUser}
+	ctx := identity.WithIdentity(context.Background(), resolved)
+
+	if _, err := gateway.CreateNetwork(ctx, connect.NewRequest(&networksv1.CreateNetworkRequest{OrganizationId: "org-1", Name: "corp"})); err != nil {
+		t.Fatalf("create network: %v", err)
+	}
+	if client.createNetworkReq.GetName() != "corp" {
+		t.Fatalf("expected create request forwarded")
+	}
+	assertMetadataValue(t, client.createNetworkMetadata, identity.MetadataKeyIdentityID, resolved.IdentityID)
+
+	_, _ = gateway.GetNetwork(context.Background(), connect.NewRequest(&networksv1.GetNetworkRequest{Id: "network-1"}))
+	_, _ = gateway.ListNetworks(context.Background(), connect.NewRequest(&networksv1.ListNetworksRequest{OrganizationId: "org-1"}))
+	_, _ = gateway.UpdateNetwork(context.Background(), connect.NewRequest(&networksv1.UpdateNetworkRequest{Id: "network-2"}))
+	_, _ = gateway.DeleteNetwork(context.Background(), connect.NewRequest(&networksv1.DeleteNetworkRequest{Id: "network-3"}))
+	_, _ = gateway.CreateTunnelCredential(context.Background(), connect.NewRequest(&networksv1.CreateTunnelCredentialRequest{NetworkId: "network-4"}))
+	_, _ = gateway.GetTunnelCredential(context.Background(), connect.NewRequest(&networksv1.GetTunnelCredentialRequest{Id: "tunnel-1"}))
+	_, _ = gateway.ListTunnelCredentials(context.Background(), connect.NewRequest(&networksv1.ListTunnelCredentialsRequest{NetworkId: "network-5"}))
+	_, _ = gateway.DeleteTunnelCredential(context.Background(), connect.NewRequest(&networksv1.DeleteTunnelCredentialRequest{Id: "tunnel-2"}))
+	_, _ = gateway.CreatePrivateResource(context.Background(), connect.NewRequest(&networksv1.CreatePrivateResourceRequest{NetworkId: "network-6", Name: "db"}))
+	_, _ = gateway.GetPrivateResource(context.Background(), connect.NewRequest(&networksv1.GetPrivateResourceRequest{Id: "resource-1"}))
+	_, _ = gateway.ListPrivateResources(context.Background(), connect.NewRequest(&networksv1.ListPrivateResourcesRequest{NetworkId: stringPtr("network-7")}))
+	_, _ = gateway.UpdatePrivateResource(context.Background(), connect.NewRequest(&networksv1.UpdatePrivateResourceRequest{Id: "resource-2"}))
+	_, _ = gateway.DeletePrivateResource(context.Background(), connect.NewRequest(&networksv1.DeletePrivateResourceRequest{Id: "resource-3"}))
+	_, _ = gateway.CreatePrivateResourceAccess(context.Background(), connect.NewRequest(&networksv1.CreatePrivateResourceAccessRequest{PrivateResourceId: "resource-4", PrincipalId: "user-2"}))
+	_, _ = gateway.DeletePrivateResourceAccess(context.Background(), connect.NewRequest(&networksv1.DeletePrivateResourceAccessRequest{Id: "access-1"}))
+	_, _ = gateway.ListPrivateResourceAccess(context.Background(), connect.NewRequest(&networksv1.ListPrivateResourceAccessRequest{PrivateResourceId: stringPtr("resource-5")}))
+
+	if client.getNetworkReq.GetId() != "network-1" || client.listNetworksReq.GetOrganizationId() != "org-1" || client.updateNetworkReq.GetId() != "network-2" || client.deleteNetworkReq.GetId() != "network-3" || client.createTunnelReq.GetNetworkId() != "network-4" || client.getTunnelReq.GetId() != "tunnel-1" || client.listTunnelsReq.GetNetworkId() != "network-5" || client.deleteTunnelReq.GetId() != "tunnel-2" || client.createResourceReq.GetNetworkId() != "network-6" || client.getResourceReq.GetId() != "resource-1" || client.listResourcesReq.GetNetworkId() != "network-7" || client.updateResourceReq.GetId() != "resource-2" || client.deleteResourceReq.GetId() != "resource-3" || client.createAccessReq.GetPrivateResourceId() != "resource-4" || client.deleteAccessReq.GetId() != "access-1" || client.listAccessReq.GetPrivateResourceId() != "resource-5" {
+		t.Fatalf("expected public network methods to be forwarded")
+	}
+}
+
+func TestNetworksGatewayMapsErrors(t *testing.T) {
+	client := &fakeNetworksClient{createNetworkErr: status.Error(codes.Unavailable, "down")}
+	_, err := NewNetworksGateway(client).CreateNetwork(context.Background(), connect.NewRequest(&networksv1.CreateNetworkRequest{}))
+	if connect.CodeOf(err) != connect.CodeUnavailable {
+		t.Fatalf("expected unavailable, got %v", err)
+	}
+}
+
+func stringPtr(value string) *string { return &value }

--- a/internal/platform/config.go
+++ b/internal/platform/config.go
@@ -29,6 +29,8 @@ const (
 	defaultRunnersGRPCTarget        = "runners:50051"
 	defaultExposeGRPCTarget         = "expose:50051"
 	defaultEgressRulesGRPCTarget    = "egress-rules:50051"
+	defaultGroupsGRPCTarget         = "groups:50051"
+	defaultNetworksGRPCTarget       = "networks:50051"
 )
 
 // Config holds the runtime configuration for communicating with upstream services.
@@ -58,6 +60,8 @@ type Config struct {
 	RunnersGRPCTarget        string
 	ExposeGRPCTarget         string
 	EgressRulesGRPCTarget    string
+	GroupsGRPCTarget         string
+	NetworksGRPCTarget       string
 }
 
 // LoadConfigFromEnv constructs a Config instance from environment variables.
@@ -115,6 +119,8 @@ func LoadConfigFromEnv() (*Config, error) {
 		RunnersGRPCTarget:        envOrDefault("RUNNERS_GRPC_TARGET", defaultRunnersGRPCTarget),
 		ExposeGRPCTarget:         envOrDefault("EXPOSE_GRPC_TARGET", defaultExposeGRPCTarget),
 		EgressRulesGRPCTarget:    envOrDefault("EGRESS_RULES_GRPC_TARGET", defaultEgressRulesGRPCTarget),
+		GroupsGRPCTarget:         envOrDefault("GROUPS_GRPC_TARGET", defaultGroupsGRPCTarget),
+		NetworksGRPCTarget:       envOrDefault("NETWORKS_GRPC_TARGET", defaultNetworksGRPCTarget),
 	}, nil
 }
 

--- a/internal/platform/config_test.go
+++ b/internal/platform/config_test.go
@@ -22,6 +22,8 @@ func TestLoadConfigFromEnv(t *testing.T) {
 	t.Setenv("RUNNERS_GRPC_TARGET", "runners:50063")
 	t.Setenv("EXPOSE_GRPC_TARGET", "expose:50065")
 	t.Setenv("EGRESS_RULES_GRPC_TARGET", "egress-rules:50066")
+	t.Setenv("GROUPS_GRPC_TARGET", "groups:50067")
+	t.Setenv("NETWORKS_GRPC_TARGET", "networks:50068")
 	t.Setenv("ZITI_ENABLED", "true")
 	t.Setenv("ZITI_LEASE_RENEWAL_INTERVAL", "3m")
 	t.Setenv("ZITI_ENROLLMENT_TIMEOUT", "90s")
@@ -100,6 +102,14 @@ func TestLoadConfigFromEnv(t *testing.T) {
 		t.Fatalf("unexpected egress rules grpc target: %s", got)
 	}
 
+	if got := cfg.GroupsGRPCTarget; got != "groups:50067" {
+		t.Fatalf("unexpected groups grpc target: %s", got)
+	}
+
+	if got := cfg.NetworksGRPCTarget; got != "networks:50068" {
+		t.Fatalf("unexpected networks grpc target: %s", got)
+	}
+
 	if !cfg.ZitiEnabled {
 		t.Fatalf("expected ziti to be enabled")
 	}
@@ -164,6 +174,8 @@ func TestLoadConfigFromEnvAllDefaults(t *testing.T) {
 	t.Setenv("RUNNERS_GRPC_TARGET", "")
 	t.Setenv("EXPOSE_GRPC_TARGET", "")
 	t.Setenv("EGRESS_RULES_GRPC_TARGET", "")
+	t.Setenv("GROUPS_GRPC_TARGET", "")
+	t.Setenv("NETWORKS_GRPC_TARGET", "")
 	t.Setenv("ZITI_ENABLED", "")
 	t.Setenv("ZITI_LEASE_RENEWAL_INTERVAL", "")
 	t.Setenv("ZITI_ENROLLMENT_TIMEOUT", "")
@@ -225,6 +237,12 @@ func TestLoadConfigFromEnvAllDefaults(t *testing.T) {
 	}
 	if cfg.EgressRulesGRPCTarget != defaultEgressRulesGRPCTarget {
 		t.Fatalf("unexpected egress rules grpc target: %s", cfg.EgressRulesGRPCTarget)
+	}
+	if cfg.GroupsGRPCTarget != defaultGroupsGRPCTarget {
+		t.Fatalf("unexpected groups grpc target: %s", cfg.GroupsGRPCTarget)
+	}
+	if cfg.NetworksGRPCTarget != defaultNetworksGRPCTarget {
+		t.Fatalf("unexpected networks grpc target: %s", cfg.NetworksGRPCTarget)
 	}
 	if cfg.ZitiEnabled {
 		t.Fatalf("expected ziti to be disabled")


### PR DESCRIPTION
## Summary
- Add GroupsGateway forwarding for all public Groups RPCs while keeping `ListMemberGroupsBatch` internal-only.
- Add NetworksGateway forwarding for network, tunnel credential, private resource, and private resource access RPCs.
- Preserve caller identity metadata via downstream context and add forwarding/error mapping tests.
- Wire Groups/Networks gRPC targets through runtime config, chart values, and CI protobuf generation.

Refs agynio/architecture#155

## Test & lint summary
- `go test ./...` — packages passed: 11; failed: 0; skipped: 0.
- `go vet ./...` — passed with no errors.
- `go build ./...` — passed.
- `helm dependency build charts/gateway && helm lint charts/gateway --set gateway.platformBaseUrl=https://platform.example.com` — charts linted: 1; failed: 0.